### PR TITLE
Fix/worker egress and latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ logs/
 build/
 bin/
 build-srt/
+build-wsl/
 external/
 # CMake artifacts
 CMakeFiles/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_compile_definitions(SLS_VERSION="${PROJECT_VERSION}")
 
 # --- External libraries ---
 find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
 
 # spdlog
 add_subdirectory(lib/spdlog)
@@ -40,6 +41,8 @@ add_subdirectory(lib/json)
 # cpp-httplib (header-only)
 add_library(httplib INTERFACE)
 target_include_directories(httplib INTERFACE ${PROJECT_SOURCE_DIR}/lib/cpp-httplib)
+target_compile_definitions(httplib INTERFACE CPPHTTPLIB_OPENSSL_SUPPORT)
+target_link_libraries(httplib INTERFACE OpenSSL::SSL OpenSSL::Crypto)
 
 # BS thread pool (header-only)
 add_library(BS_thread_pool INTERFACE)

--- a/src/core/AsyncHttpClient.cpp
+++ b/src/core/AsyncHttpClient.cpp
@@ -58,7 +58,7 @@ AsyncHttpResponse AsyncHttpClient::execute_get(const std::string& url, int timeo
             return response;
         }
 
-        httplib::Client client(host, port);
+        httplib::Client client(scheme + "://" + host + ":" + std::to_string(port));
         client.set_connection_timeout(timeout_sec, 0);
         client.set_read_timeout(timeout_sec, 0);
         client.set_write_timeout(timeout_sec, 0);
@@ -106,7 +106,7 @@ AsyncHttpResponse AsyncHttpClient::execute_post(const std::string& url,
             return response;
         }
 
-        httplib::Client client(host, port);
+        httplib::Client client(scheme + "://" + host + ":" + std::to_string(port));
         client.set_connection_timeout(timeout_sec, 0);
         client.set_read_timeout(timeout_sec, 0);
         client.set_write_timeout(timeout_sec, 0);
@@ -148,14 +148,17 @@ bool AsyncHttpClient::parse_url(const std::string& url,
     }
 
     scheme = url.substr(0, scheme_end);
+    if (scheme != "http" && scheme != "https") {
+        return false;
+    }
     size_t host_start = scheme_end + 3;
     
-    size_t path_start = url.find('/', host_start);
+    size_t path_start = url.find_first_of("/?", host_start);
     std::string host_port;
     
     if (path_start != std::string::npos) {
         host_port = url.substr(host_start, path_start - host_start);
-        path = url.substr(path_start);
+        path = url[path_start] == '?' ? "/" + url.substr(path_start) : url.substr(path_start);
     } else {
         host_port = url.substr(host_start);
         path = "/";
@@ -168,6 +171,9 @@ bool AsyncHttpClient::parse_url(const std::string& url,
     } else {
         host = host_port;
         port = (scheme == "https") ? 443 : 80;
+    }
+    if (host.empty() || port <= 0 || port > 65535) {
+        return false;
     }
 
     return true;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,6 +6,10 @@ set(sls_core_files
 	constants.hpp
 	AsyncHttpClient.cpp
 	AsyncHttpClient.hpp
+	auth_reject_cache.cpp
+	auth_reject_cache.hpp
+	sls_sid.cpp
+	sls_sid.hpp
 	README.md
 	SLSArray.cpp
 	SLSArray.hpp

--- a/src/core/SLSGroup.cpp
+++ b/src/core/SLSGroup.cpp
@@ -52,6 +52,7 @@ CSLSGroup::CSLSGroup()
 
     m_stat_post_last_tm_ms = sls_gettime_ms();
     m_stat_post_interval = 5; // 5s default
+    m_last_idle_check_ms = 0; // force idle_check on the first iteration
 }
 CSLSGroup::~CSLSGroup()
 {
@@ -178,7 +179,7 @@ int CSLSGroup::handler()
         else
             ret = CSLSSrt::libsrt_neterrno();
 
-        idle_check();
+        maybe_idle_check();
         return handler_count;
     }
 
@@ -256,7 +257,7 @@ int CSLSGroup::handler()
         }
     }
 
-    idle_check();
+    maybe_idle_check();
 
     // Spin guard. Player sockets stay registered for SRT_EPOLL_OUT for
     // their whole lifetime. An SRT socket that has drained its send
@@ -287,6 +288,25 @@ void CSLSGroup::idle_check()
     check_reconnect_relay();
     check_invalid_sock();
     check_new_role();
+}
+
+void CSLSGroup::maybe_idle_check()
+{
+    // Housekeeping (relay reconnects, dead-socket cleanup + per-role
+    // srt_getsockstate, new-role pickup, stats) is cheap per call but
+    // not free: check_invalid_sock alone issues one libsrt syscall per
+    // role, each taking libsrt's global control lock. The data loop can
+    // spin thousands of times/sec while a publisher streams, so running
+    // this every iteration starves libsrt's own send/recv/ACK threads
+    // of that lock. Gating to POLLING_TIME restores the cadence the
+    // pre-eventfd loop had (its unconditional trailing msleep paced the
+    // whole loop to ~POLLING_TIME) without reintroducing that sleep on
+    // the data path.
+    int64_t now_ms = sls_gettime_ms();
+    if (now_ms - m_last_idle_check_ms < POLLING_TIME)
+        return;
+    m_last_idle_check_ms = now_ms;
+    idle_check();
 }
 
 void CSLSGroup::check_wait_http_role()

--- a/src/core/SLSGroup.cpp
+++ b/src/core/SLSGroup.cpp
@@ -29,15 +29,23 @@
 #include "SLSGroup.hpp"
 #include "SLSLog.hpp"
 
-// Upper bound on idle-check cadence. The worker blocks in srt_epoll_wait
-// up to this long when there are no socket events AND no wake() pending.
-// Real socket events return immediately via libsrt's epoll. Explicit
-// wakes (stop, reload, new role queued) are delivered via the eventfd
-// registered in CSLSEpollThread::init_epoll, so this timeout only
-// gates the periodic idle housekeeping (relay reconnects, invalid-sock
-// cleanup, picking up newly-queued roles). 50ms gives ~20 idle ticks
-// per second with no per-event latency cost.
-#define POLLING_TIME 50
+// Max time the worker blocks in srt_epoll_wait when nothing is ready.
+// Since players/pushers are no longer permanently armed for
+// SRT_EPOLL_OUT (see CSLSSrt::libsrt_add_to_epoll), egress is driven by
+// the worker's periodic pass over the publisher ring; for a viewer whose
+// publisher lives in a *different* worker, this timeout is therefore the
+// worst-case forwarding latency (that worker has no SRT event to wake it
+// when ring data arrives). 10ms keeps cross-worker egress latency well
+// inside any viewer's TSBPD budget while costing only ~100 idle wakeups
+// per second per worker (each a tiny no-op pass), with no busy-spin
+// because nothing is permanently writable.
+#define POLLING_TIME 10
+
+// Housekeeping cadence (idle_check). Decoupled from POLLING_TIME so the
+// per-role srt_getsockstate sweep and role-list pops run at a steady
+// ~20 Hz regardless of how often the egress tick fires. See
+// maybe_idle_check.
+#define IDLE_CHECK_INTERVAL 50
 
 /**
  * CSLSGroup class implementation
@@ -163,9 +171,12 @@ int CSLSGroup::handler()
     }
 
     // Event-driven wait. Blocks up to POLLING_TIME ms unless a socket
-    // event fires or wake() is called via the eventfd (registered as a
-    // system socket in CSLSEpollThread::init_epoll). No follow-up sleep:
-    // when there's nothing to do, we just sit in srt_epoll_wait.
+    // event fires (publisher IN, a backpressured role's OUT once its send
+    // buffer drains, or any role's ERR) or wake() is called via the
+    // eventfd. On timeout we still fall through to the egress pass below,
+    // because writable roles are no longer permanently armed for OUT and
+    // a role whose publisher lives in another worker has no SRT event to
+    // wake this one when fresh ring data appears.
     ret = srt_epoll_wait(m_eid, m_read_socks, &read_len,
                          m_write_socks, &write_len,
                          POLLING_TIME,
@@ -174,107 +185,99 @@ int CSLSGroup::handler()
     if (ret < 0)
     {
         ret = srt_getlasterror(NULL);
-        if (ret == SRT_ETIMEOUT) // 6003
-            ret = SLSERROR(EAGAIN);
-        else
-            ret = CSLSSrt::libsrt_neterrno();
-
-        maybe_idle_check();
-        return handler_count;
+        if (ret != SRT_ETIMEOUT) // 6003: ordinary idle timeout, not an error
+            CSLSSrt::libsrt_neterrno();
+        // No usable read/write sets on this path; skip the read loop and
+        // go straight to the egress pass + housekeeping.
+        read_len = 0;
     }
-
-    // Drain the wake fd if it fired. We don't care which fd specifically
-    // (only one is registered today) — drain_wake_fd is idempotent.
-    if (sys_read_len > 0)
+    else
     {
-        drain_wake_fd();
-    }
-
-    spdlog::trace("[{}] CSLSGroup::handle, worker_number={:d}, writable sock count={:d}, readable sock count={:d}.",
-                  fmt::ptr(this), m_worker_number, write_len, read_len);
-
-    for (i = 0; i < write_len; i++)
-    {
-        std::map<int, CSLSRole *>::iterator it = m_map_role.find(m_write_socks[i]);
-        if (it == m_map_role.end())
+        // Drain the wake fd if it fired. We don't care which fd
+        // specifically (only one is registered today) — drain_wake_fd is
+        // idempotent.
+        if (sys_read_len > 0)
         {
-            spdlog::warn("[{}] CSLSGroup::handle, worker_number={:d}, no role map writable sock={:d}, why?",
-                         fmt::ptr(this), m_worker_number, m_write_socks[i]);
-            continue;
+            drain_wake_fd();
         }
 
+        spdlog::trace("[{}] CSLSGroup::handle, worker_number={:d}, writable sock count={:d}, readable sock count={:d}.",
+                      fmt::ptr(this), m_worker_number, write_len, read_len);
+
+        // Reads: publishers and pullers. (Writable roles are serviced by
+        // the egress pass below, not from m_write_socks — OUT events only
+        // matter as a wake signal for backpressure recovery, which the
+        // pass then handles.)
+        for (i = 0; i < read_len; i++)
+        {
+            std::map<int, CSLSRole *>::iterator it = m_map_role.find(m_read_socks[i]);
+            if (it == m_map_role.end())
+            {
+                spdlog::warn("[{}] CSLSGroup::handle, worker_number={:d}, no role map readable sock={:d}, why?",
+                             fmt::ptr(this), m_worker_number, m_read_socks[i]);
+                continue;
+            }
+
+            CSLSRole *role = it->second;
+            if (!role)
+            {
+                spdlog::warn("[{}] CSLSGroup::handle, worker_number={:d}, role is null, readable sock={:d}, why?",
+                             fmt::ptr(this), m_worker_number, m_read_socks[i]);
+                continue;
+            }
+
+            ret = role->handler();
+            if (ret < 0)
+            {
+                // handle exception
+                spdlog::trace("[{}] CSLSGroup::handle, worker_number={:d}, readable sock={:d} is invalid, {}={}, readable len={:d}, role_map.size={:d}.",
+                              fmt::ptr(this), m_worker_number, m_read_socks[i], role->get_role_name(), fmt::ptr(role), read_len, m_map_role.size());
+                role->invalid_srt();
+            }
+            else
+            {
+                handler_count += ret;
+            }
+        }
+    }
+
+    // Egress pass. Players/pushers register ERR-only and are driven from
+    // here rather than from a permanently-armed SRT_EPOLL_OUT (which, being
+    // level-triggered, would make srt_epoll_wait busy-return every
+    // iteration and peg a core). Forward any newly-available publisher-ring
+    // data to every writable role, then let the role arm/disarm OUT based
+    // on whether it is backpressured. invalid_srt() here does not erase
+    // from m_map_role (check_invalid_sock does, later), so iterating is
+    // safe.
+    for (std::map<int, CSLSRole *>::iterator it = m_map_role.begin(); it != m_map_role.end(); ++it)
+    {
         CSLSRole *role = it->second;
-        if (!role)
-        {
-            spdlog::warn("[{}] CSLSGroup::handle, worker_number={:d}, role is null, writable sock={:d}, why?",
-                         fmt::ptr(this), m_worker_number, m_write_socks[i]);
+        if (!role || !role->is_write())
             continue;
-        }
 
         ret = role->handler();
         if (ret < 0)
         {
-            // handle exception
-            spdlog::trace("[{}] CSLSGroup::handle, worker_number={:d}, write sock={:d} is invalid, {}={}, write_len={:d}, role_map.size={:d}.",
-                          fmt::ptr(this), m_worker_number, m_write_socks[i], role->get_role_name(), fmt::ptr(role), write_len, m_map_role.size());
+            spdlog::trace("[{}] CSLSGroup::handle, worker_number={:d}, egress sock={:d} is invalid, {}={}, role_map.size={:d}.",
+                          fmt::ptr(this), m_worker_number, it->first, role->get_role_name(), fmt::ptr(role), m_map_role.size());
             role->invalid_srt();
         }
         else
         {
             handler_count += ret;
-        }
-    }
-
-    for (i = 0; i < read_len; i++)
-    {
-        std::map<int, CSLSRole *>::iterator it = m_map_role.find(m_read_socks[i]);
-        if (it == m_map_role.end())
-        {
-            spdlog::warn("[{}] CSLSGroup::handle, worker_number={:d}, no role map readable sock={:d}, why?",
-                         fmt::ptr(this), m_worker_number, m_read_socks[i]);
-            continue;
-        }
-
-        CSLSRole *role = it->second;
-        if (!role)
-        {
-            spdlog::warn("[{}] CSLSGroup::handle, worker_number={:d}, role is null, readable sock={:d}, why?",
-                         fmt::ptr(this), m_worker_number, m_read_socks[i]);
-            continue;
-        }
-
-        ret = role->handler();
-        if (ret < 0)
-        {
-            // handle exception
-            spdlog::trace("[{}] CSLSGroup::handle, worker_number={:d}, readable sock={:d} is invalid, {}={}, readable len={:d}, role_map.size={:d}.",
-                          fmt::ptr(this), m_worker_number, m_read_socks[i], role->get_role_name(), fmt::ptr(role), read_len, m_map_role.size());
-            role->invalid_srt();
-        }
-        else
-        {
-            handler_count += ret;
+            role->update_egress_arming();
         }
     }
 
     maybe_idle_check();
 
-    // Spin guard. Player sockets stay registered for SRT_EPOLL_OUT for
-    // their whole lifetime. An SRT socket that has drained its send
-    // buffer is *always* writable, so level-triggered srt_epoll_wait
-    // returns it on every iteration with zero blocking — even when the
-    // publisher ring has no new data for that player yet. Without a
-    // floor we then busy-loop calling handler_write_data -> get() ->
-    // "no data" -> return, pegging a core (the pre-eventfd code hid
-    // this behind its unconditional trailing msleep).
-    //
-    // handler_count is the bytes actually moved this iteration (publisher
-    // reads + player writes). If it's zero, every returned socket was a
-    // no-op writable player and we should yield briefly instead of
-    // spinning. When real data is flowing handler_count > 0 and we loop
-    // immediately with no added latency. 2ms is far below any player's
-    // TSBPD budget (>=200ms) so it is invisible to playback while
-    // capping idle spin at ~500 wakeups/sec/worker.
+    // Safety floor. With nothing permanently armed for OUT the worker
+    // normally parks in srt_epoll_wait (up to POLLING_TIME) when idle, so
+    // this rarely fires. It only guards the case where srt_epoll_wait
+    // returns immediately with events that move no bytes (e.g. a
+    // backpressured role's OUT flapping while its link is congested):
+    // yield briefly instead of spinning. 2ms is far below any viewer's
+    // TSBPD budget so playback is unaffected.
     if (handler_count == 0)
     {
         msleep(2);
@@ -303,7 +306,7 @@ void CSLSGroup::maybe_idle_check()
     // whole loop to ~POLLING_TIME) without reintroducing that sleep on
     // the data path.
     int64_t now_ms = sls_gettime_ms();
-    if (now_ms - m_last_idle_check_ms < POLLING_TIME)
+    if (now_ms - m_last_idle_check_ms < IDLE_CHECK_INTERVAL)
         return;
     m_last_idle_check_ms = now_ms;
     idle_check();

--- a/src/core/SLSGroup.cpp
+++ b/src/core/SLSGroup.cpp
@@ -252,7 +252,15 @@ int CSLSGroup::handler()
     for (std::map<int, CSLSRole *>::iterator it = m_map_role.begin(); it != m_map_role.end(); ++it)
     {
         CSLSRole *role = it->second;
-        if (!role || !role->is_write())
+        if (!role)
+            continue;
+
+        // Periodic hook for every role, independent of socket events. The
+        // listener uses it to complete deferred player accepts whose async
+        // validation has resolved, even when no new connection arrives.
+        role->on_worker_tick();
+
+        if (!role->is_write())
             continue;
 
         ret = role->handler();

--- a/src/core/SLSGroup.hpp
+++ b/src/core/SLSGroup.hpp
@@ -64,6 +64,10 @@ private:
     std::list<CSLSRelayManager *> m_list_reconnect_relay_manager;
 
     void idle_check();
+    // Runs idle_check() only if at least POLLING_TIME ms have elapsed
+    // since the last run, so worker housekeeping keeps its original
+    // ~POLLING_TIME cadence regardless of how hot the data loop spins.
+    void maybe_idle_check();
     void check_reconnect_relay();
     void check_invalid_sock();
     void check_new_role();
@@ -76,6 +80,11 @@ private:
 
     int64_t m_stat_post_last_tm_ms;
     int m_stat_post_interval;
+    // Wall-clock (ms) of the last idle_check() run. idle_check does
+    // per-role libsrt syscalls (srt_getsockstate) plus role-list pops;
+    // running it every worker iteration hammers libsrt's global control
+    // lock at spin frequency. Gate it to POLLING_TIME cadence instead.
+    int64_t m_last_idle_check_ms;
     CSLSMutex m_mutex_stat;
     std::vector<stat_info_t> m_stat_info;
 };

--- a/src/core/SLSListener.hpp
+++ b/src/core/SLSListener.hpp
@@ -121,6 +121,7 @@ public:
     virtual int stop();
 
     virtual int handler();
+    virtual void on_worker_tick();
 
     void set_role_list(CSLSRoleList *list_role);
     void set_map_publisher(CSLSMapPublisher *publisher);
@@ -208,6 +209,41 @@ private:
     // owning worker owns these futures (the pool runs the request), so there
     // is no detached cross-thread access to this listener. Worker-thread-only.
     std::map<std::string, std::shared_future<AsyncHttpResponse>> m_pending_player_key_validations;
+
+    // A player connection accepted at the SRT layer but held while its
+    // player-key webhook is still in flight (deferred accept). The socket
+    // stays open so a one-shot client (VLC, ffplay) that does not reconnect
+    // still gets in: once the validation resolves the worker completes the
+    // accept, or closes the socket on rejection/timeout. Worker-thread-only.
+    struct PendingPlayerConnection {
+        CSLSSrt *srt = nullptr;
+        std::string app_uplive;   // publisher uplive for the player's app (from the original sid)
+        std::string player_key;   // key being validated; also the cache lookup key
+        std::string session_id;
+        std::string peer_name;
+        int peer_port = 0;
+        int final_latency = 0;
+        std::string cur_time;
+        std::chrono::steady_clock::time_point deadline{};
+    };
+    std::vector<PendingPlayerConnection> m_pending_player_connections;
+    // Complete a player accept once the (possibly player-key-resolved) stream
+    // is known. Shared by the synchronous accept path and the deferred path.
+    // Takes ownership of `srt`: on every return the socket has either been
+    // handed to a pushed CSLSPlayer or been closed and deleted. Returns 1.
+    int finish_player_accept(CSLSSrt *srt,
+                             const std::string &app_uplive,
+                             const std::string &stream_name,
+                             const std::string &effective_sid,
+                             const std::string &player_key,
+                             bool player_key_validation_required,
+                             const char *peer_name, int peer_port,
+                             int final_latency,
+                             const std::string &session_id,
+                             const std::string &cur_time);
+    // Advance held connections: finish those whose validation resolved valid,
+    // close those rejected or past their deadline. Worker-tick driven.
+    void drive_pending_player_connections();
 
     // Rate limiting structure
     struct RateLimitEntry {

--- a/src/core/SLSListener.hpp
+++ b/src/core/SLSListener.hpp
@@ -70,6 +70,7 @@ int player_key_min_length;
 char default_sid[STR_MAX_LEN];
 char srt_passphrase[80];
 int srt_pbkeylen;
+int peer_idle_timeout; //SRTO_PEERIDLETIMEO (ms) applied to accepted sockets; 0 = libsrt/fork default
 SLS_CONF_DYNAMIC_DECLARE_END
 
 /**
@@ -97,6 +98,7 @@ SLS_SET_CONF(server, string, domain_player, "play domain", 1, URL_MAX_LEN - 1),
     SLS_SET_CONF(server, string, default_sid, "default sid to use when no streamid is given", 1, STR_MAX_LEN - 1),
     SLS_SET_CONF(server, string, srt_passphrase, "listener-wide SRT passphrase (10-79 bytes; empty = no encryption)", 0, 79),
     SLS_SET_CONF(server, int, srt_pbkeylen, "SRT key length: 0/16/24/32 (0 = libsrt default)", 0, 32),
+    SLS_SET_CONF(server, int, peer_idle_timeout, "SRTO_PEERIDLETIMEO (ms) for accepted sockets; reaps dead publishers faster (0 = libsrt/fork default)", 0, 60000),
     SLS_CONF_CMD_DYNAMIC_DECLARE_END
 
     /**

--- a/src/core/SLSListener.hpp
+++ b/src/core/SLSListener.hpp
@@ -71,6 +71,7 @@ char default_sid[STR_MAX_LEN];
 char srt_passphrase[80];
 int srt_pbkeylen;
 int peer_idle_timeout; //SRTO_PEERIDLETIMEO (ms) applied to accepted sockets; 0 = libsrt/fork default
+int auth_reject_cache_ttl; //negative-auth-cache TTL (seconds); 0 = default 30
 SLS_CONF_DYNAMIC_DECLARE_END
 
 /**
@@ -99,6 +100,7 @@ SLS_SET_CONF(server, string, domain_player, "play domain", 1, URL_MAX_LEN - 1),
     SLS_SET_CONF(server, string, srt_passphrase, "listener-wide SRT passphrase (10-79 bytes; empty = no encryption)", 0, 79),
     SLS_SET_CONF(server, int, srt_pbkeylen, "SRT key length: 0/16/24/32 (0 = libsrt default)", 0, 32),
     SLS_SET_CONF(server, int, peer_idle_timeout, "SRTO_PEERIDLETIMEO (ms) for accepted sockets; reaps dead publishers faster (0 = libsrt/fork default)", 0, 60000),
+    SLS_SET_CONF(server, int, auth_reject_cache_ttl, "negative auth cache TTL in seconds; rejects recently-failed publisher keys at the handshake (0 = default 30)", 0, 3600),
     SLS_CONF_CMD_DYNAMIC_DECLARE_END
 
     /**

--- a/src/core/SLSListener.hpp
+++ b/src/core/SLSListener.hpp
@@ -175,12 +175,28 @@ private:
     };
     std::map<std::string, PlayerKeyCacheEntry> m_player_key_cache;
     std::mutex m_cache_mutex;
-    
+    // Last time expired entries were swept from m_player_key_cache. The cache
+    // is otherwise only pruned lazily when the same key is looked up again, so
+    // a flood of distinct never-recurring keys would leak entries until their
+    // TTL without this periodic sweep. Guarded by m_cache_mutex.
+    std::chrono::steady_clock::time_point m_last_player_key_cache_sweep{};
+    // Insert with eviction, assumes m_cache_mutex is already held. Drops
+    // expired entries first, then (if still at the hard cap) the soonest-to-
+    // expire entry, so the map can never grow without bound under a rotating-
+    // key flood while freshly validated hot entries are preserved.
+    void insert_player_key_cache_locked(const std::string& key, const PlayerKeyCacheEntry& entry);
+    // Time-gated sweep of expired player-key cache entries. Cheap no-op when
+    // called more than once within the sweep interval.
+    void sweep_player_key_cache();
+
     // Rate limiting structure
     struct RateLimitEntry {
         std::deque<std::chrono::steady_clock::time_point> request_times;
     };
     std::map<std::string, RateLimitEntry> m_rate_limit_map;
+    // Throttles cleanup_expired_rate_limits so the full-map scan runs at most
+    // once per second instead of on every player accept.
+    std::chrono::steady_clock::time_point m_last_rate_limit_cleanup{};
     
     // Per-stream player limit override structure
     struct StreamPlayerLimitEntry {

--- a/src/core/SLSListener.hpp
+++ b/src/core/SLSListener.hpp
@@ -35,11 +35,13 @@
 #include "SLSMapPublisher.hpp"
 #include "SLSMapRelay.hpp"
 #include "SLSSrt.hpp"
+#include "AsyncHttpClient.hpp"
 #include <map>
 #include <chrono>
 #include <regex>
 #include <deque>
 #include <mutex>
+#include <future>
 
 /**
  * server conf
@@ -136,11 +138,25 @@ public:
     virtual stat_info_t get_stat_info();
 
 protected:
+    // Returns SLS_OK (resolved from cache), SLS_ERROR (hard reject: bad
+    // format, rate limited, or a cached negative result), or SLS_PENDING (no
+    // cached result yet; an async webhook validation has been kicked off and
+    // this connection should be rejected so the client's reconnect can hit the
+    // now-populated cache). Never blocks the worker on the network.
     int validate_player_key(const char* player_key, char* resolved_stream_id, size_t resolved_stream_id_size, const char* client_ip = nullptr);
     bool is_rate_limited(const char* client_ip);
     bool validate_player_key_format(const char* player_key);
     void cleanup_expired_rate_limits();
     void update_rate_limit(const char* client_ip);
+    // Kick a webhook validation for an uncached key into the AsyncHttpClient
+    // pool (deduplicated and capped) without waiting for it. Worker-only.
+    void start_player_key_validation(const std::string& key, const char* client_ip);
+    // Turn a completed webhook response into a positive/negative cache entry.
+    void process_player_key_response(const std::string& key, const AsyncHttpResponse& response);
+    // Poll in-flight validations; fold any that have completed into the cache.
+    // Called at the top of handler() so a reconnect sees the prior attempt's
+    // result. Worker-only.
+    void drain_player_key_validations();
 
 private:
     CSLSRoleList *m_list_role;
@@ -188,6 +204,10 @@ private:
     // Time-gated sweep of expired player-key cache entries. Cheap no-op when
     // called more than once within the sweep interval.
     void sweep_player_key_cache();
+    // In-flight player-key webhook validations, keyed by player key. The
+    // owning worker owns these futures (the pool runs the request), so there
+    // is no detached cross-thread access to this listener. Worker-thread-only.
+    std::map<std::string, std::shared_future<AsyncHttpResponse>> m_pending_player_key_validations;
 
     // Rate limiting structure
     struct RateLimitEntry {

--- a/src/core/SLSListenerAuth.cpp
+++ b/src/core/SLSListenerAuth.cpp
@@ -24,6 +24,11 @@ constexpr auto PLAYER_KEY_CACHE_SWEEP_INTERVAL = std::chrono::seconds(5);
 constexpr size_t MAX_RATE_LIMIT_ENTRIES = 100000;
 // Minimum spacing between full sweeps of the rate-limit map.
 constexpr auto RATE_LIMIT_CLEANUP_INTERVAL = std::chrono::seconds(1);
+// Hard ceiling on concurrent in-flight player-key webhook validations. Bounds
+// both the pending map and the webhook backlog a flood of distinct uncached
+// keys can create. They drain quickly (the pool processes them), so this is
+// only reached under abuse.
+constexpr size_t MAX_PENDING_PLAYER_KEY_VALIDATIONS = 1024;
 } // namespace
 
 void CSLSListener::insert_player_key_cache_locked(const std::string& key, const PlayerKeyCacheEntry& entry)
@@ -242,97 +247,113 @@ int CSLSListener::validate_player_key(const char* player_key, char* resolved_str
         }
     }
 
+    // Cache miss: validate asynchronously so the worker is never blocked on
+    // the webhook. Reject this connection now and let the result populate the
+    // cache; the client (e.g. OBS, which reconnects automatically while a
+    // stream key is valid) hits the cache on its retry. This trades one
+    // reconnect cycle of latency on a cold key for never parking a worker
+    // thread on a slow or unreachable auth backend.
+    start_player_key_validation(key_str, client_ip);
+    return SLS_PENDING;
+}
+
+void CSLSListener::start_player_key_validation(const std::string& key, const char* client_ip)
+{
+    // One in-flight webhook per key is enough; concurrent reconnects for the
+    // same key share the single outstanding validation.
+    if (m_pending_player_key_validations.find(key) != m_pending_player_key_validations.end()) {
+        return;
+    }
+    // Bound concurrent outstanding validations so a flood of distinct uncached
+    // keys cannot grow the pending map or the webhook backlog without limit.
+    if (m_pending_player_key_validations.size() >= MAX_PENDING_PLAYER_KEY_VALIDATIONS) {
+        spdlog::warn("[{}] CSLSListener::start_player_key_validation, pending validation cap reached ({}), deferring key='{}'.",
+                     fmt::ptr(this), m_pending_player_key_validations.size(), key);
+        return;
+    }
+
+    // Count the webhook against the source IP's rate budget on dispatch.
     if (client_ip) {
         update_rate_limit(client_ip);
     }
 
-    // Build auth URL
     char auth_url[URL_MAX_LEN * 2] = {0};
     if (strlen(m_player_key_auth_url) > URL_MAX_LEN - 100) {
-        spdlog::error("[{}] CSLSListener::validate_player_key, base auth URL too long.", fmt::ptr(this));
-        return SLS_ERROR;
+        spdlog::error("[{}] CSLSListener::start_player_key_validation, base auth URL too long.", fmt::ptr(this));
+        return;
     }
     int ret = snprintf(auth_url, sizeof(auth_url), "%s?player_key=%s",
-                       m_player_key_auth_url, url_encode(player_key).c_str());
+                       m_player_key_auth_url, url_encode(key).c_str());
     if (ret < 0 || (unsigned)ret >= sizeof(auth_url)) {
-        spdlog::error("[{}] CSLSListener::validate_player_key, auth URL too long, ret={:d}.", fmt::ptr(this), ret);
-        return SLS_ERROR;
+        spdlog::error("[{}] CSLSListener::start_player_key_validation, auth URL too long, ret={:d}.", fmt::ptr(this), ret);
+        return;
     }
 
-    // Use AsyncHttpClient - this executes in thread pool
-    int timeout_sec = (m_player_key_auth_timeout + 999) / 1000; // Round up to seconds
-    auto future = AsyncHttpClient::instance().get_async(auth_url, timeout_sec);
-    
-    // Wait for result (blocks this thread, but NOT the listener thread if called from worker)
-    // IMPORTANT: The listener thread should never call this directly!
-    auto response = future.get();
-    
+    int timeout_sec = (m_player_key_auth_timeout + 999) / 1000; // round up to seconds
+    m_pending_player_key_validations[key] =
+        AsyncHttpClient::instance().get_async(auth_url, timeout_sec);
+    spdlog::debug("[{}] CSLSListener::start_player_key_validation, dispatched webhook for key='{}'.", fmt::ptr(this), key);
+}
+
+void CSLSListener::process_player_key_response(const std::string& key, const AsyncHttpResponse& response)
+{
+    auto now = std::chrono::steady_clock::now();
+
+    auto cache_negative = [&]() {
+        PlayerKeyCacheEntry e;
+        e.resolved_stream_id = "";
+        e.is_valid = false;
+        e.expiry_time = now + std::chrono::milliseconds(m_player_key_cache_duration / 4);
+        e.has_max_players_override = false;
+        e.max_players_per_stream_override = -1;
+        std::lock_guard<std::mutex> lk(m_cache_mutex);
+        insert_player_key_cache_locked(key, e);
+    };
+
     if (!response.success) {
-        spdlog::error("[{}] CSLSListener::validate_player_key, HTTP request failed: {}",
-                     fmt::ptr(this), response.error);
-        PlayerKeyCacheEntry negative_cache_entry;
-        negative_cache_entry.resolved_stream_id = "";
-        negative_cache_entry.is_valid = false;
-        negative_cache_entry.expiry_time = now + std::chrono::milliseconds(m_player_key_cache_duration / 4);
-        negative_cache_entry.has_max_players_override = false;
-        negative_cache_entry.max_players_per_stream_override = -1;
-        {
-            std::lock_guard<std::mutex> lk(m_cache_mutex);
-            insert_player_key_cache_locked(key_str, negative_cache_entry);
-        }
-        spdlog::debug("[{}] CSLSListener::validate_player_key, cached negative result for player_key='{}', expires in {}ms.",
-                     fmt::ptr(this), player_key, m_player_key_cache_duration / 4);
-        return SLS_ERROR;
+        spdlog::error("[{}] CSLSListener::process_player_key_response, HTTP request failed for key='{}': {}",
+                     fmt::ptr(this), key, response.error);
+        cache_negative();
+        return;
     }
 
     if (response.status_code != 200) {
-        spdlog::error("[{}] CSLSListener::validate_player_key, API returned error code: {}, response: '{}'.",
-                     fmt::ptr(this), response.status_code, response.body.c_str());
-        PlayerKeyCacheEntry negative_cache_entry;
-        negative_cache_entry.resolved_stream_id = "";
-        negative_cache_entry.is_valid = false;
-        negative_cache_entry.expiry_time = now + std::chrono::milliseconds(m_player_key_cache_duration / 4);
-        negative_cache_entry.has_max_players_override = false;
-        negative_cache_entry.max_players_per_stream_override = -1;
-        {
-            std::lock_guard<std::mutex> lk(m_cache_mutex);
-            insert_player_key_cache_locked(key_str, negative_cache_entry);
-        }
-        spdlog::debug("[{}] CSLSListener::validate_player_key, cached negative result for player_key='{}', expires in {}ms.",
-                     fmt::ptr(this), player_key, m_player_key_cache_duration / 4);
-        return SLS_ERROR;
+        spdlog::error("[{}] CSLSListener::process_player_key_response, API returned error code {} for key='{}', response: '{}'.",
+                     fmt::ptr(this), response.status_code, key, response.body.c_str());
+        cache_negative();
+        return;
     }
-
-    std::string response_content = response.body;
 
     std::string stream_id;
     int json_max_players_override = -1;
     bool json_has_max_players_override = false;
     try {
-        nlohmann::json json_response = nlohmann::json::parse(response_content);
+        nlohmann::json json_response = nlohmann::json::parse(response.body);
         if (json_response.contains("stream_id") && json_response["stream_id"].is_string()) {
             stream_id = json_response["stream_id"];
         } else {
-            spdlog::error("[{}] CSLSListener::validate_player_key, JSON response missing 'stream_id' field or field is not a string.", fmt::ptr(this));
-            return SLS_ERROR;
+            spdlog::error("[{}] CSLSListener::process_player_key_response, JSON response missing 'stream_id' for key='{}'.", fmt::ptr(this), key);
+            return;
         }
         if (json_response.contains("max_players_per_stream")) {
             if (json_response["max_players_per_stream"].is_number_integer()) {
                 json_max_players_override = json_response["max_players_per_stream"].get<int>();
                 json_has_max_players_override = true;
             } else {
-                spdlog::warn("[{}] CSLSListener::validate_player_key, 'max_players_per_stream' present but not an integer; ignoring.", fmt::ptr(this));
+                spdlog::warn("[{}] CSLSListener::process_player_key_response, 'max_players_per_stream' present but not an integer for key='{}'; ignoring.", fmt::ptr(this), key);
             }
         }
     } catch (const nlohmann::json::exception& e) {
-        spdlog::error("[{}] CSLSListener::validate_player_key, failed to parse JSON response: {}.", fmt::ptr(this), e.what());
-        return SLS_ERROR;
+        spdlog::error("[{}] CSLSListener::process_player_key_response, failed to parse JSON for key='{}': {}.", fmt::ptr(this), key, e.what());
+        return;
     }
 
-    if (stream_id.empty() || stream_id.length() >= resolved_stream_id_size) {
-        spdlog::error("[{}] CSLSListener::validate_player_key, invalid or empty stream_id returned: '{}'.",
-                     fmt::ptr(this), stream_id.c_str());
-        return SLS_ERROR;
+    // Reject a resolved id that would not fit the handler's streamid buffer
+    // rather than silently truncating it into a different stream key.
+    if (stream_id.empty() || stream_id.length() >= URL_MAX_LEN) {
+        spdlog::error("[{}] CSLSListener::process_player_key_response, invalid or empty stream_id '{}' for key='{}'.",
+                     fmt::ptr(this), stream_id.c_str(), key);
+        return;
     }
 
     PlayerKeyCacheEntry cache_entry;
@@ -343,14 +364,27 @@ int CSLSListener::validate_player_key(const char* player_key, char* resolved_str
     cache_entry.max_players_per_stream_override = json_max_players_override;
     {
         std::lock_guard<std::mutex> lk(m_cache_mutex);
-        insert_player_key_cache_locked(key_str, cache_entry);
+        insert_player_key_cache_locked(key, cache_entry);
     }
 
-    spdlog::debug("[{}] CSLSListener::validate_player_key, cached result for player_key='{}', expires in {}ms.{}",
-                 fmt::ptr(this), player_key, m_player_key_cache_duration,
+    spdlog::debug("[{}] CSLSListener::process_player_key_response, cached result for key='{}', resolved to '{}', expires in {}ms.{}",
+                 fmt::ptr(this), key, stream_id, m_player_key_cache_duration,
                  cache_entry.has_max_players_override ? " (with per-key max_players_per_stream override)" : "");
+}
 
-    strlcpy(resolved_stream_id, stream_id.c_str(), resolved_stream_id_size);
-
-    return SLS_OK;
+void CSLSListener::drain_player_key_validations()
+{
+    if (m_pending_player_key_validations.empty()) {
+        return;
+    }
+    using namespace std::chrono_literals;
+    for (auto it = m_pending_player_key_validations.begin(); it != m_pending_player_key_validations.end();) {
+        if (it->second.wait_for(0ms) != std::future_status::ready) {
+            ++it;
+            continue;
+        }
+        AsyncHttpResponse response = it->second.get();
+        process_player_key_response(it->first, response);
+        it = m_pending_player_key_validations.erase(it);
+    }
 }

--- a/src/core/SLSListenerAuth.cpp
+++ b/src/core/SLSListenerAuth.cpp
@@ -12,6 +12,67 @@
 
 using namespace std;
 
+namespace {
+// Hard ceiling on cached player keys. Each entry is a key string plus a
+// resolved stream id (both bounded by the streamid buffer), so this bounds
+// the cache's memory. Sized well above any plausible legitimate concurrent
+// audience; only a rotating-key flood ever reaches it.
+constexpr size_t MAX_PLAYER_KEY_CACHE_ENTRIES = 50000;
+// Minimum spacing between full expired-entry sweeps of the player-key cache.
+constexpr auto PLAYER_KEY_CACHE_SWEEP_INTERVAL = std::chrono::seconds(5);
+// Hard ceiling on tracked source IPs for player-key rate limiting.
+constexpr size_t MAX_RATE_LIMIT_ENTRIES = 100000;
+// Minimum spacing between full sweeps of the rate-limit map.
+constexpr auto RATE_LIMIT_CLEANUP_INTERVAL = std::chrono::seconds(1);
+} // namespace
+
+void CSLSListener::insert_player_key_cache_locked(const std::string& key, const PlayerKeyCacheEntry& entry)
+{
+    // Refreshing an existing key never grows the map.
+    auto existing = m_player_key_cache.find(key);
+    if (existing != m_player_key_cache.end()) {
+        existing->second = entry;
+        return;
+    }
+
+    if (m_player_key_cache.size() >= MAX_PLAYER_KEY_CACHE_ENTRIES) {
+        auto now = std::chrono::steady_clock::now();
+        for (auto it = m_player_key_cache.begin(); it != m_player_key_cache.end();) {
+            if (it->second.expiry_time <= now)
+                it = m_player_key_cache.erase(it);
+            else
+                ++it;
+        }
+        // All remaining entries are still live: evict the one closest to
+        // expiring so a valid, recently validated key is the last to go.
+        if (m_player_key_cache.size() >= MAX_PLAYER_KEY_CACHE_ENTRIES) {
+            auto victim = m_player_key_cache.begin();
+            for (auto it = std::next(m_player_key_cache.begin()); it != m_player_key_cache.end(); ++it) {
+                if (it->second.expiry_time < victim->second.expiry_time)
+                    victim = it;
+            }
+            if (victim != m_player_key_cache.end())
+                m_player_key_cache.erase(victim);
+        }
+    }
+    m_player_key_cache[key] = entry;
+}
+
+void CSLSListener::sweep_player_key_cache()
+{
+    auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lk(m_cache_mutex);
+    if (now - m_last_player_key_cache_sweep < PLAYER_KEY_CACHE_SWEEP_INTERVAL)
+        return;
+    m_last_player_key_cache_sweep = now;
+    for (auto it = m_player_key_cache.begin(); it != m_player_key_cache.end();) {
+        if (it->second.expiry_time <= now)
+            it = m_player_key_cache.erase(it);
+        else
+            ++it;
+    }
+}
+
 bool CSLSListener::validate_player_key_format(const char* player_key)
 {
     if (!player_key) {
@@ -85,12 +146,45 @@ void CSLSListener::update_rate_limit(const char* client_ip)
 
     auto now = std::chrono::steady_clock::now();
     std::string ip_str(client_ip);
+
+    // Cap the number of tracked source IPs so a distributed / spoofed-source
+    // flood cannot grow the map without bound. A new IP that would exceed the
+    // cap forces an immediate sweep; if the map is still full of live entries
+    // the new IP is simply left untracked (not rate-limited) rather than
+    // admitted, which keeps memory bounded without locking out the existing
+    // tracked sources.
+    if (m_rate_limit_map.find(ip_str) == m_rate_limit_map.end() &&
+        m_rate_limit_map.size() >= MAX_RATE_LIMIT_ENTRIES) {
+        auto window_start = now - std::chrono::milliseconds(m_player_key_rate_limit_window * 2);
+        for (auto it = m_rate_limit_map.begin(); it != m_rate_limit_map.end();) {
+            RateLimitEntry& entry = it->second;
+            while (!entry.request_times.empty() && entry.request_times.front() < window_start) {
+                entry.request_times.pop_front();
+            }
+            if (entry.request_times.empty()) {
+                it = m_rate_limit_map.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        if (m_rate_limit_map.size() >= MAX_RATE_LIMIT_ENTRIES) {
+            return;
+        }
+    }
+
     m_rate_limit_map[ip_str].request_times.push_back(now);
 }
 
 void CSLSListener::cleanup_expired_rate_limits()
 {
     auto now = std::chrono::steady_clock::now();
+    // Time-gate the full-map scan: is_rate_limited calls this on every player
+    // accept, but the per-IP deque trim there already keeps the checked IP
+    // correct, so the map-wide GC only needs to run periodically.
+    if (now - m_last_rate_limit_cleanup < RATE_LIMIT_CLEANUP_INTERVAL) {
+        return;
+    }
+    m_last_rate_limit_cleanup = now;
     auto window_start = now - std::chrono::milliseconds(m_player_key_rate_limit_window * 2);
 
     for (auto it = m_rate_limit_map.begin(); it != m_rate_limit_map.end();) {
@@ -184,7 +278,7 @@ int CSLSListener::validate_player_key(const char* player_key, char* resolved_str
         negative_cache_entry.max_players_per_stream_override = -1;
         {
             std::lock_guard<std::mutex> lk(m_cache_mutex);
-            m_player_key_cache[key_str] = negative_cache_entry;
+            insert_player_key_cache_locked(key_str, negative_cache_entry);
         }
         spdlog::debug("[{}] CSLSListener::validate_player_key, cached negative result for player_key='{}', expires in {}ms.",
                      fmt::ptr(this), player_key, m_player_key_cache_duration / 4);
@@ -202,7 +296,7 @@ int CSLSListener::validate_player_key(const char* player_key, char* resolved_str
         negative_cache_entry.max_players_per_stream_override = -1;
         {
             std::lock_guard<std::mutex> lk(m_cache_mutex);
-            m_player_key_cache[key_str] = negative_cache_entry;
+            insert_player_key_cache_locked(key_str, negative_cache_entry);
         }
         spdlog::debug("[{}] CSLSListener::validate_player_key, cached negative result for player_key='{}', expires in {}ms.",
                      fmt::ptr(this), player_key, m_player_key_cache_duration / 4);
@@ -249,7 +343,7 @@ int CSLSListener::validate_player_key(const char* player_key, char* resolved_str
     cache_entry.max_players_per_stream_override = json_max_players_override;
     {
         std::lock_guard<std::mutex> lk(m_cache_mutex);
-        m_player_key_cache[key_str] = cache_entry;
+        insert_player_key_cache_locked(key_str, cache_entry);
     }
 
     spdlog::debug("[{}] CSLSListener::validate_player_key, cached result for player_key='{}', expires in {}ms.{}",

--- a/src/core/SLSListenerConfig.cpp
+++ b/src/core/SLSListenerConfig.cpp
@@ -1,6 +1,7 @@
 #include "SLSListener.hpp"
 #include "SLSMapPublisher.hpp"
 #include "SLSMapRelay.hpp"
+#include "auth_reject_cache.hpp"
 #include "spdlog/spdlog.h"
 #include <regex>
 #include <vector>
@@ -80,6 +81,11 @@ int CSLSListener::init_conf_app()
     m_player_key_rate_limit_window = conf_server->player_key_rate_limit_window;
     m_player_key_max_length = conf_server->player_key_max_length;
     m_player_key_min_length = conf_server->player_key_min_length;
+
+    // The cache itself is owned by CSLSManager and shared across listeners;
+    // set_ttl ignores a zero/unset value and keeps the 30s default.
+    if (m_auth_reject_cache)
+        m_auth_reject_cache->set_ttl(conf_server->auth_reject_cache_ttl);
 
     char regex_pattern[256];
     snprintf(regex_pattern, sizeof(regex_pattern), "^[\\x20-\\x7E]{%d,%d}$",

--- a/src/core/SLSListenerCore.cpp
+++ b/src/core/SLSListenerCore.cpp
@@ -1,6 +1,7 @@
 #include "SLSListener.hpp"
 #include "SLSSrt.hpp"
 #include "SLSRoleList.hpp"
+#include "sls_sid.hpp"
 #include "spdlog/spdlog.h"
 #include <string.h>
 #include <errno.h>
@@ -256,6 +257,20 @@ int CSLSListener::start()
     {
         spdlog::error("[listener] Start failed, libsrt_listen error | port={}", m_port);
         return ret;
+    }
+
+    // Reject malformed streamids and recently-failed publisher keys during the
+    // handshake, before srt_accept and any webhook. Publisher listeners only
+    // (the DoS-relevant path); the negative cache is passed as the opaque and
+    // may be null, in which case only the format gate applies. Non-fatal: a
+    // failure here just falls back to the post-accept validation.
+    if (m_is_publisher_listener)
+    {
+        if (m_srt->libsrt_set_listen_callback(sls_publisher_listen_callback,
+                                              m_auth_reject_cache.get()) != SLS_OK)
+        {
+            spdlog::warn("[listener] set_listen_callback failed | port={}", m_port);
+        }
     }
 
     if (sls_should_log_category(SLSLogCategory::LISTENER, spdlog::level::debug)) {

--- a/src/core/SLSListenerCore.cpp
+++ b/src/core/SLSListenerCore.cpp
@@ -233,6 +233,12 @@ int CSLSListener::start()
                      m_port, server_conf->srt_pbkeylen);
     }
 
+    // Inherited by every accepted socket on this listener. See libsrt_setup
+    // for the bonding-tolerance tradeoff; 0 leaves the fork default.
+    if (server_conf->peer_idle_timeout > 0) {
+        m_srt->libsrt_set_peer_idle_timeout(server_conf->peer_idle_timeout);
+    }
+
     ret = m_srt->libsrt_setup(m_port, use_srtla_patches);
     if (SLS_OK != ret)
     {

--- a/src/core/SLSListenerCore.cpp
+++ b/src/core/SLSListenerCore.cpp
@@ -272,6 +272,18 @@ int CSLSListener::start()
             spdlog::warn("[listener] set_listen_callback failed | port={}", m_port);
         }
     }
+    else
+    {
+        // Player listeners get a format-only gate: reject malformed streamids
+        // at the handshake so a garbage-streamid flood never reaches
+        // srt_accept. No auth cache here (the player path authorizes via the
+        // player_key webhook post-accept, not the publisher negative cache).
+        if (m_srt->libsrt_set_listen_callback(sls_player_listen_callback,
+                                              nullptr) != SLS_OK)
+        {
+            spdlog::warn("[listener] set_listen_callback (player) failed | port={}", m_port);
+        }
+    }
 
     if (sls_should_log_category(SLSLogCategory::LISTENER, spdlog::level::debug)) {
 			spdlog::debug("[listener] Checking role list");

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -750,6 +750,9 @@ int CSLSListener::handler()
     pub->set_stat_info_base(*stat_info_obj);
 
     pub->set_http_url(m_http_url_role);
+    // Hand the publisher the shared negative-auth cache so a non-200 webhook
+    // response records this streamid for handshake-time rejection of repeats.
+    pub->set_auth_reject_cache(m_auth_reject_cache);
 
     spdlog::info("[{}] CSLSListener::handler, new pub={}, key_stream_name={}.",
                  fmt::ptr(this), fmt::ptr(pub), key_stream_name);

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -91,6 +91,17 @@ int CSLSListener::handler()
 
     final_latency = negotiated_latency;
 
+    // A connection landing below latency_min means the listener floor
+    // (SRTO_LATENCY/RCVLATENCY set in CSLSListener::start) did not reach
+    // this socket. Warn rather than silently run a too-tight TSBPD window.
+    if (conf_server->latency_min > 0 && negotiated_latency > 0 &&
+        negotiated_latency < conf_server->latency_min)
+    {
+        spdlog::warn("[connection:{}] {} {}:{} negotiated latency {} ms below latency_min {} ms.",
+                     session_id, m_is_publisher_listener ? "publisher" : "player",
+                     peer_name, peer_port, negotiated_latency, conf_server->latency_min);
+    }
+
     if (0 != srt->libsrt_getsockopt(SRTO_STREAMID, "SRTO_STREAMID", &sid, &sid_size)) {
         spdlog::error("[{}] CSLSListener::handler, [{}:{:d}], fd={:d}, get streamid info failed.",
                       fmt::ptr(this), peer_name, peer_port, srt->libsrt_get_fd());

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -14,6 +14,16 @@
 #include <string.h>
 #include <chrono>
 
+namespace {
+// Hard ceiling on the shared handoff list (roles accepted by a listener but
+// not yet picked up by a worker). Under normal operation workers drain this
+// to near-zero; it only backs up when accepts outpace the workers, i.e. a
+// connection flood. Refusing new accepts past this keeps the list (and the
+// live role/object count it feeds) bounded. Generous so it never trips under
+// legitimate load.
+constexpr int MAX_HANDOFF_BACKLOG = 4096;
+} // namespace
+
 int CSLSListener::handler()
 {
     cleanupExpiredStreamOverrides();
@@ -66,6 +76,25 @@ int CSLSListener::handler()
                      session_id, peer_name, peer_port, fd_client,
                      m_is_publisher_listener ? "publisher" : "player",
                      m_is_legacy_listener, m_port);
+    }
+
+    // Global backpressure: if the shared handoff list (roles accepted but not
+    // yet picked up by a worker) has backed up past the ceiling, the workers
+    // cannot keep pace, so stop admitting new connections until it drains
+    // instead of letting accepts pile up unbounded. Self-correcting: size()
+    // falls as workers pop, so there is no counter to leak. Log is
+    // rate-limited to avoid amplifying a flood into log spam.
+    if (m_list_role != NULL && m_list_role->size() >= MAX_HANDOFF_BACKLOG) {
+        std::string rate_key = std::string("handoff_backlog:") + std::to_string(m_port);
+        CSLSLogRateLimiter::EventStats stats;
+        if (!sls_get_log_config().rate_limit_enabled ||
+            sls_get_rate_limiter().should_log(rate_key, stats)) {
+            spdlog::warn("[{}] CSLSListener::handler, refused [{}:{:d}]: handoff backlog at ceiling ({}), workers overloaded.",
+                         fmt::ptr(this), peer_name, peer_port, MAX_HANDOFF_BACKLOG);
+        }
+        srt->libsrt_close();
+        delete srt;
+        return client_count;
     }
 
     sls_conf_server_t* conf_server = (sls_conf_server_t*)m_conf;

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -682,8 +682,31 @@ int CSLSListener::handler()
 
     CSLSRole *publisher = m_map_publisher->get_publisher(key_stream_name);
     if (NULL != publisher) {
-        spdlog::error("[{}] CSLSListener::handler, refused, new role[{}:{:d}], stream='{}',but publisher={} is not NULL.",
-                      fmt::ptr(this), peer_name, peer_port, key_stream_name, fmt::ptr(publisher));
+        // Publisher takeover. A publisher is already registered for this
+        // stream, but a fresh connection for the same key is almost always
+        // the same encoder reconnecting (SRTLA link flap / SRT session
+        // reset). The incumbent's socket can squat the key for the whole
+        // idle_streams_timeout: the peer's SHUTDOWN is sent over the same
+        // flapping path and routinely never arrives, so SLS only notices the
+        // stale publisher via the idle timer (~10s of black screen on every
+        // reconnect). Instead, mark the incumbent for teardown so its owning
+        // worker reaps it within one idle tick (~50ms) through the normal
+        // cleanup path; the encoder's next reconnect then registers cleanly.
+        //
+        // We still refuse THIS connection rather than adopting its socket in
+        // place: evicting the incumbent and swapping in the new socket
+        // atomically would mean touching the incumbent's map_data ring (shared
+        // with any current players) and publisher entry from the listener
+        // thread while another worker still owns that role — not safe. One
+        // extra reconnect is a fine price for staying race-free.
+        //
+        // Caveat: this is last-writer-wins. Two distinct encoders configured
+        // with the same stream key will evict each other on a loop. That
+        // requires possession of the (secret) stream key and passing the IP
+        // ACL, and is logged below so operators can spot it.
+        publisher->request_kick();
+        spdlog::warn("[{}] CSLSListener::handler, publisher takeover for stream='{}', evicting stale publisher={}, new role[{}:{:d}] will reconnect.",
+                     fmt::ptr(this), key_stream_name, fmt::ptr(publisher), peer_name, peer_port);
         srt->libsrt_close();
         delete srt;
         return client_count;

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -18,6 +18,10 @@ int CSLSListener::handler()
 {
     cleanupExpiredStreamOverrides();
     sweep_player_key_cache();
+    // Fold any completed async player-key webhooks into the cache before this
+    // accept's lookup, so a client's reconnect after a cold-key rejection sees
+    // the now-resolved result.
+    drain_player_key_validations();
     int ret = SLS_OK;
     int fd_client = 0;
     CSLSSrt *srt = NULL;
@@ -365,6 +369,16 @@ int CSLSListener::handler()
         }
 
         int validation_result = validate_player_key(player_key, validated_stream_id, sizeof(validated_stream_id), peer_name);
+        if (validation_result == SLS_PENDING) {
+            // Uncached key: an async webhook validation was dispatched and this
+            // connection is rejected without blocking the worker. An
+            // auto-reconnecting client will hit the populated cache on retry.
+            spdlog::debug("[connection:{}] Player key '{}' from {}:{} - validation pending, client should retry",
+                         session_id, player_key, peer_name, peer_port);
+            srt->libsrt_close();
+            delete srt;
+            return client_count;
+        }
         if (validation_result != SLS_OK) {
             spdlog::error("[{}] CSLSListener::handler, [{}:{:d}], player key validation FAILED for key='{}'",
                          fmt::ptr(this), peer_name, peer_port, player_key);

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -548,7 +548,10 @@ int CSLSListener::handler()
                 }
             } else {
                 spdlog::error("[{}] CSLSListener::handler ACL check failed: could not get peer address", fmt::ptr(this));
-                spdlog::error("[{}] CSLSListener::handler Accepting connection by default", fmt::ptr(this));
+                spdlog::error("[{}] CSLSListener::handler Rejecting connection by default", fmt::ptr(this));
+                srt->libsrt_close();
+                delete srt;
+                return client_count;
             }
         }
 
@@ -695,7 +698,10 @@ int CSLSListener::handler()
         }
     } else {
         spdlog::error("[{}] CSLSListener::handler ACL check failed: could not get peer address", fmt::ptr(this));
-        spdlog::error("[{}] CSLSListener::handler Accepting connection by default", fmt::ptr(this));
+        spdlog::error("[{}] CSLSListener::handler Rejecting connection by default", fmt::ptr(this));
+        srt->libsrt_close();
+        delete srt;
+        return client_count;
     }
 
     CSLSRole *publisher = m_map_publisher->get_publisher(key_stream_name);

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -22,16 +22,18 @@ namespace {
 // live role/object count it feeds) bounded. Generous so it never trips under
 // legitimate load.
 constexpr int MAX_HANDOFF_BACKLOG = 4096;
+// Hard ceiling on player connections held open awaiting their async
+// player-key validation (deferred accept). Bounds the open SRT sockets a
+// flood of uncached keys can park; past it, a new uncached connection is
+// refused outright instead of held.
+constexpr size_t MAX_PENDING_PLAYER_CONNECTIONS = 1024;
 } // namespace
 
 int CSLSListener::handler()
 {
-    cleanupExpiredStreamOverrides();
-    sweep_player_key_cache();
-    // Fold any completed async player-key webhooks into the cache before this
-    // accept's lookup, so a client's reconnect after a cold-key rejection sees
-    // the now-resolved result.
-    drain_player_key_validations();
+    // Periodic maintenance (override sweep, player-key cache sweep, draining
+    // completed async validations, advancing deferred accepts) runs in
+    // on_worker_tick on every worker pass, not just on a new connection.
     int ret = SLS_OK;
     int fd_client = 0;
     CSLSSrt *srt = NULL;
@@ -399,13 +401,33 @@ int CSLSListener::handler()
 
         int validation_result = validate_player_key(player_key, validated_stream_id, sizeof(validated_stream_id), peer_name);
         if (validation_result == SLS_PENDING) {
-            // Uncached key: an async webhook validation was dispatched and this
-            // connection is rejected without blocking the worker. An
-            // auto-reconnecting client will hit the populated cache on retry.
-            spdlog::debug("[connection:{}] Player key '{}' from {}:{} - validation pending, client should retry",
+            // Uncached key: an async webhook validation was dispatched. Hold
+            // the accepted socket open (deferred accept) instead of rejecting,
+            // so a one-shot client that does not auto-reconnect (VLC, ffplay)
+            // still gets in once the validation resolves. The worker completes
+            // or closes it in drive_pending_player_connections. srt ownership
+            // transfers to the pending list on success below.
+            if (m_pending_player_connections.size() >= MAX_PENDING_PLAYER_CONNECTIONS) {
+                spdlog::warn("[connection:{}] deferred player accept: pending cap reached ({}), refusing key='{}'.",
+                             session_id, m_pending_player_connections.size(), player_key);
+                srt->libsrt_close();
+                delete srt;
+                return client_count;
+            }
+            PendingPlayerConnection pend;
+            pend.srt = srt;
+            pend.app_uplive = app_uplive;
+            pend.player_key = player_key;
+            pend.session_id = session_id;
+            pend.peer_name = peer_name;
+            pend.peer_port = peer_port;
+            pend.final_latency = final_latency;
+            pend.cur_time = cur_time;
+            pend.deadline = std::chrono::steady_clock::now() +
+                            std::chrono::milliseconds(m_player_key_auth_timeout + 2000);
+            m_pending_player_connections.push_back(std::move(pend));
+            spdlog::debug("[connection:{}] Player key '{}' from {}:{} - validation pending, holding connection",
                          session_id, player_key, peer_name, peer_port);
-            srt->libsrt_close();
-            delete srt;
             return client_count;
         }
         if (validation_result != SLS_OK) {
@@ -471,235 +493,9 @@ int CSLSListener::handler()
     }
 
     if (app_uplive.length() > 0) {
-        snprintf(key_stream_name, sizeof(key_stream_name), "%s/%s", app_uplive.c_str(), stream_name);
-        if (player_key_validation_required) {
-            auto now_ts = std::chrono::steady_clock::now();
-            PlayerKeyCacheEntry entry;
-            bool found_entry = false;
-            {
-                std::lock_guard<std::mutex> lk(m_cache_mutex);
-                auto it_cache = m_player_key_cache.find(std::string(player_key));
-                if (it_cache != m_player_key_cache.end()) {
-                    entry = it_cache->second;
-                    found_entry = true;
-                }
-            }
-            if (found_entry) {
-                if (entry.is_valid && now_ts < entry.expiry_time && entry.has_max_players_override) {
-                    StreamPlayerLimitEntry stream_entry;
-                    stream_entry.has_override = true;
-                    stream_entry.max_players_per_stream = entry.max_players_per_stream_override;
-                    stream_entry.expiry_time = entry.expiry_time;
-                    m_stream_player_limit_map[std::string(key_stream_name)] = stream_entry;
-                }
-            }
-        }
-        CSLSRole *pub = m_map_publisher->get_publisher(key_stream_name);
-        if (NULL == pub) {
-            if (NULL == m_map_puller) {
-                // Rate-limit "stream offline" logs to reduce noise from repeated reconnection attempts
-                std::string rate_key = std::string(peer_name) + ":stream_offline:" + key_stream_name;
-                CSLSLogRateLimiter::EventStats stats;
-                if (sls_get_log_config().rate_limit_enabled &&
-                    !sls_get_rate_limiter().should_log(rate_key, stats)) {
-                    spdlog::debug("[connection:{}] Stream '{}' offline, refusing {}:{} (suppressed, {} attempts)",
-                                 session_id, key_stream_name, peer_name, peer_port, stats.count);
-                } else {
-                    spdlog::info("[{}] CSLSListener::handler, refused, new role[{}:{:d}], stream='{}', publisher is NULL and m_map_puller is NULL.",
-                                 fmt::ptr(this), peer_name, peer_port, key_stream_name);
-                }
-                srt->libsrt_close();
-                delete srt;
-                return client_count;
-            }
-            CSLSRelayManager *puller_manager = m_map_puller->add_relay_manager(app_uplive.c_str(), stream_name);
-            if (NULL == puller_manager) {
-                srt->libsrt_close();
-                delete srt;
-                return client_count;
-            }
-
-            puller_manager->set_map_data(m_map_data);
-            puller_manager->set_map_publisher(m_map_publisher);
-            puller_manager->set_role_list(m_list_role);
-            puller_manager->set_listen_port(m_port);
-
-            if (SLS_OK != puller_manager->start()) {
-                spdlog::info("[{}] CSLSListener::handler, puller_manager->start failed, new client[{}:{:d}], stream='{}'.",
-                             fmt::ptr(this), peer_name, peer_port, key_stream_name);
-                srt->libsrt_close();
-                delete srt;
-                return client_count;
-            }
-            spdlog::info("[{}] CSLSListener::handler, puller_manager->start ok, new client[{}:{:d}], stream={}.",
-                         fmt::ptr(this), peer_name, peer_port, key_stream_name);
-
-            pub = m_map_publisher->get_publisher(key_stream_name);
-            if (NULL == pub) {
-                // Rate-limit "publisher not ready" logs to reduce noise from repeated reconnection attempts
-                std::string rate_key = std::string(peer_name) + ":pub_not_ready:" + key_stream_name;
-                CSLSLogRateLimiter::EventStats stats;
-                if (sls_get_log_config().rate_limit_enabled &&
-                    !sls_get_rate_limiter().should_log(rate_key, stats)) {
-                    spdlog::debug("[connection:{}] Publisher not ready for '{}', refusing {}:{} (suppressed, {} attempts)",
-                                 session_id, key_stream_name, peer_name, peer_port, stats.count);
-                } else {
-                    spdlog::warn("[{}] CSLSListener::handler, publisher not ready after puller start, new client[{}:{:d}], stream='{}'. Client should retry.",
-                                 fmt::ptr(this), peer_name, peer_port, key_stream_name);
-                }
-                srt->libsrt_close();
-                delete srt;
-                return client_count;
-            }
-            spdlog::info("[{}] CSLSListener::handler, m_map_publisher->get_publisher ok, pub={}, new client[{}:{:d}], stream='{}'.",
-                         fmt::ptr(this), fmt::ptr(pub), peer_name, peer_port, key_stream_name);
-        }
-
-        ca = (sls_conf_app_t *)m_map_publisher->get_ca(app_uplive);
-        if (ca == nullptr) {
-            spdlog::error("[{}] CSLSListener::handler, refused, configuration does not exist [stream={}]",
-                           fmt::ptr(this), key_stream_name);
-            srt->libsrt_close();
-            delete srt;
-            return client_count;
-        } else {
-            if (srt->libsrt_getpeeraddr_raw(peer_addr_raw, peer_addr6_raw) == SLS_OK) {
-                bool address_matched = false;
-                for (sls_ip_access_t &acl_entry : ca->ip_actions.play) {
-                    if (acl_entry.ip_address == peer_addr_raw || acl_entry.ip_address == 0) {
-                        switch (acl_entry.action) {
-                        case sls_access_action::ACCEPT:
-                            address_matched = true;
-                            spdlog::info("[{}] CSLSListener::handler Accepted connection from {}:{:d} for app '{}'",
-                                         fmt::ptr(this), peer_name, peer_port, ca->app_publisher);
-                            break;
-                        case sls_access_action::DENY:
-                            spdlog::warn("[{}] CSLSListener::handler Rejected connection from {}:{:d} for app '{}'",
-                                         fmt::ptr(this), peer_name, peer_port, ca->app_publisher);
-                            srt->libsrt_close();
-                            delete srt;
-                            return client_count;
-                        default:
-                            spdlog::error("[{}] CSLSListener::handler Unknown action [sls_access_action={:d}], ignoring",
-                                          fmt::ptr(this), (int)acl_entry.action);
-                        }
-                    }
-                    if (address_matched) break;
-                }
-                if (!address_matched) {
-                    spdlog::info("[{}] CSLSListener::handler Accepted connection from {}:{:d} for app '{}' by default",
-                                 fmt::ptr(this), peer_name, peer_port, ca->app_publisher);
-                }
-            } else {
-                spdlog::error("[{}] CSLSListener::handler ACL check failed: could not get peer address", fmt::ptr(this));
-                spdlog::error("[{}] CSLSListener::handler Rejecting connection by default", fmt::ptr(this));
-                srt->libsrt_close();
-                delete srt;
-                return client_count;
-            }
-        }
-
-        CSLSRole *pub_check = m_map_publisher->get_publisher(key_stream_name);
-        if (NULL == pub_check) {
-            spdlog::error("[{}] CSLSListener::handler, refused, new role[{}:{:d}], stream={}, publisher no longer exists.",
-                          fmt::ptr(this), peer_name, peer_port, key_stream_name);
-            srt->libsrt_close();
-            delete srt;
-            return client_count;
-        }
-
-        {
-            int effective_max_players = ca->max_players_per_stream;
-            bool using_override = false;
-            auto now_ts = std::chrono::steady_clock::now();
-
-            auto it_stream_cap = m_stream_player_limit_map.find(std::string(key_stream_name));
-            if (it_stream_cap != m_stream_player_limit_map.end()) {
-                const StreamPlayerLimitEntry &sentry = it_stream_cap->second;
-                if (sentry.has_override && now_ts < sentry.expiry_time) {
-                    effective_max_players = sentry.max_players_per_stream;
-                    using_override = true;
-                } else if (now_ts >= sentry.expiry_time) {
-                    m_stream_player_limit_map.erase(it_stream_cap);
-                }
-            }
-
-            if (!using_override && player_key_validation_required) {
-                PlayerKeyCacheEntry entry;
-                bool found_entry = false;
-                {
-                    std::lock_guard<std::mutex> lk(m_cache_mutex);
-                    auto it_cache = m_player_key_cache.find(std::string(player_key));
-                    if (it_cache != m_player_key_cache.end()) {
-                        entry = it_cache->second;
-                        found_entry = true;
-                    }
-                }
-                if (found_entry) {
-                    if (entry.is_valid && now_ts < entry.expiry_time && entry.has_max_players_override) {
-                        effective_max_players = entry.max_players_per_stream_override;
-                        using_override = true;
-                    }
-                }
-            }
-
-            if (effective_max_players > 0) {
-                int current_player_count = m_list_role->count_players_for_stream(key_stream_name);
-                if (current_player_count >= effective_max_players) {
-                    spdlog::warn("[{}] CSLSListener::handler, refused, new player[{}:{:d}], stream={}, player limit reached ({:d}/{:d}){}.",
-                                 fmt::ptr(this), peer_name, peer_port, key_stream_name, current_player_count, effective_max_players,
-                                 using_override ? " [override]" : "");
-                    srt->libsrt_close();
-                    delete srt;
-                    return client_count;
-                }
-                spdlog::debug("[{}] CSLSListener::handler, new player[{}:{:d}], stream={}, player count ({:d}/{:d}){}.",
-                              fmt::ptr(this), peer_name, peer_port, key_stream_name, current_player_count, effective_max_players,
-                              using_override ? " [override]" : "");
-            }
-        }
-
-        if (srt->libsrt_socket_nonblock(0) < 0)
-            spdlog::warn("[{}] CSLSListener::handler, new player[{}:{:d}], libsrt_socket_nonblock failed.",
-                         fmt::ptr(this), peer_name, peer_port);
-
-        CSLSPlayer *player = new CSLSPlayer;
-        if (NULL == player) {
-            spdlog::error("[{}] CSLSListener::handler, failed to allocate player for [{}:{:d}]",
-                         fmt::ptr(this), peer_name, peer_port);
-            srt->libsrt_close();
-            delete srt;
-            return client_count;
-        }
-
-        player->init();
-        player->set_idle_streams_timeout(m_idle_streams_timeout_role);
-        player->set_srt(srt);
-        player->set_map_data(key_stream_name, m_map_data);
-        player->set_latency(final_latency);
-        // Seed the role's streamid with the (possibly player-key-resolved) sid
-        // so downstream hooks like on_event_url report the real stream instead
-        // of the raw SRTO_STREAMID the client sent.
-        player->set_streamid(sid);
-
-        stat_info_t *stat_info_obj = new stat_info_t();
-        stat_info_obj->port = m_port;
-        stat_info_obj->role = player->get_role_name();
-        stat_info_obj->pub_domain_app = app_uplive;
-        stat_info_obj->stream_name = stream_name;
-        stat_info_obj->url = sid;
-        stat_info_obj->remote_ip = peer_name;
-        stat_info_obj->remote_port = peer_port;
-        stat_info_obj->start_time = cur_time;
-        player->set_stat_info_base(*stat_info_obj);
-
-        player->set_http_url(m_http_url_role);
-        player->on_connect();
-
-        m_list_role->push(player);
-        spdlog::info("[{}] CSLSListener::handler, new player[{}] =[{}:{:d}], key_stream_name={}, {}={}, m_list_role->size={:d}.",
-                     fmt::ptr(this), fmt::ptr(player), peer_name, peer_port, key_stream_name, player->get_role_name(), fmt::ptr(player), m_list_role->size());
-        return client_count;
+        return finish_player_accept(srt, app_uplive, stream_name, sid,
+                                    std::string(player_key), player_key_validation_required,
+                                    peer_name, peer_port, final_latency, session_id, cur_time);
     }
 
     app_uplive = key_app;
@@ -874,6 +670,323 @@ void CSLSListener::cleanupExpiredStreamOverrides()
             it = m_stream_player_limit_map.erase(it);
         } else {
             ++it;
+        }
+    }
+}
+
+int CSLSListener::finish_player_accept(CSLSSrt *srt,
+                                       const std::string &app_uplive,
+                                       const std::string &stream_name,
+                                       const std::string &effective_sid,
+                                       const std::string &player_key,
+                                       bool player_key_validation_required,
+                                       const char *peer_name, int peer_port,
+                                       int final_latency,
+                                       const std::string &session_id,
+                                       const std::string &cur_time)
+{
+    int client_count = 1;
+    char key_stream_name[URL_MAX_LEN] = {0};
+    unsigned long peer_addr_raw = 0;
+    struct in6_addr peer_addr6_raw;
+    sls_conf_app_t *ca = NULL;
+
+    snprintf(key_stream_name, sizeof(key_stream_name), "%s/%s", app_uplive.c_str(), stream_name.c_str());
+    if (player_key_validation_required) {
+        auto now_ts = std::chrono::steady_clock::now();
+        PlayerKeyCacheEntry entry;
+        bool found_entry = false;
+        {
+            std::lock_guard<std::mutex> lk(m_cache_mutex);
+            auto it_cache = m_player_key_cache.find(player_key);
+            if (it_cache != m_player_key_cache.end()) {
+                entry = it_cache->second;
+                found_entry = true;
+            }
+        }
+        if (found_entry) {
+            if (entry.is_valid && now_ts < entry.expiry_time && entry.has_max_players_override) {
+                StreamPlayerLimitEntry stream_entry;
+                stream_entry.has_override = true;
+                stream_entry.max_players_per_stream = entry.max_players_per_stream_override;
+                stream_entry.expiry_time = entry.expiry_time;
+                m_stream_player_limit_map[std::string(key_stream_name)] = stream_entry;
+            }
+        }
+    }
+    CSLSRole *pub = m_map_publisher->get_publisher(key_stream_name);
+    if (NULL == pub) {
+        if (NULL == m_map_puller) {
+            // Rate-limit "stream offline" logs to reduce noise from repeated reconnection attempts
+            std::string rate_key = std::string(peer_name) + ":stream_offline:" + key_stream_name;
+            CSLSLogRateLimiter::EventStats stats;
+            if (sls_get_log_config().rate_limit_enabled &&
+                !sls_get_rate_limiter().should_log(rate_key, stats)) {
+                spdlog::debug("[connection:{}] Stream '{}' offline, refusing {}:{} (suppressed, {} attempts)",
+                             session_id, key_stream_name, peer_name, peer_port, stats.count);
+            } else {
+                spdlog::info("[{}] CSLSListener::handler, refused, new role[{}:{:d}], stream='{}', publisher is NULL and m_map_puller is NULL.",
+                             fmt::ptr(this), peer_name, peer_port, key_stream_name);
+            }
+            srt->libsrt_close();
+            delete srt;
+            return client_count;
+        }
+        CSLSRelayManager *puller_manager = m_map_puller->add_relay_manager(app_uplive.c_str(), stream_name.c_str());
+        if (NULL == puller_manager) {
+            srt->libsrt_close();
+            delete srt;
+            return client_count;
+        }
+
+        puller_manager->set_map_data(m_map_data);
+        puller_manager->set_map_publisher(m_map_publisher);
+        puller_manager->set_role_list(m_list_role);
+        puller_manager->set_listen_port(m_port);
+
+        if (SLS_OK != puller_manager->start()) {
+            spdlog::info("[{}] CSLSListener::handler, puller_manager->start failed, new client[{}:{:d}], stream='{}'.",
+                         fmt::ptr(this), peer_name, peer_port, key_stream_name);
+            srt->libsrt_close();
+            delete srt;
+            return client_count;
+        }
+        spdlog::info("[{}] CSLSListener::handler, puller_manager->start ok, new client[{}:{:d}], stream={}.",
+                     fmt::ptr(this), peer_name, peer_port, key_stream_name);
+
+        pub = m_map_publisher->get_publisher(key_stream_name);
+        if (NULL == pub) {
+            // Rate-limit "publisher not ready" logs to reduce noise from repeated reconnection attempts
+            std::string rate_key = std::string(peer_name) + ":pub_not_ready:" + key_stream_name;
+            CSLSLogRateLimiter::EventStats stats;
+            if (sls_get_log_config().rate_limit_enabled &&
+                !sls_get_rate_limiter().should_log(rate_key, stats)) {
+                spdlog::debug("[connection:{}] Publisher not ready for '{}', refusing {}:{} (suppressed, {} attempts)",
+                             session_id, key_stream_name, peer_name, peer_port, stats.count);
+            } else {
+                spdlog::warn("[{}] CSLSListener::handler, publisher not ready after puller start, new client[{}:{:d}], stream='{}'. Client should retry.",
+                             fmt::ptr(this), peer_name, peer_port, key_stream_name);
+            }
+            srt->libsrt_close();
+            delete srt;
+            return client_count;
+        }
+        spdlog::info("[{}] CSLSListener::handler, m_map_publisher->get_publisher ok, pub={}, new client[{}:{:d}], stream='{}'.",
+                     fmt::ptr(this), fmt::ptr(pub), peer_name, peer_port, key_stream_name);
+    }
+
+    ca = (sls_conf_app_t *)m_map_publisher->get_ca(app_uplive);
+    if (ca == nullptr) {
+        spdlog::error("[{}] CSLSListener::handler, refused, configuration does not exist [stream={}]",
+                       fmt::ptr(this), key_stream_name);
+        srt->libsrt_close();
+        delete srt;
+        return client_count;
+    } else {
+        if (srt->libsrt_getpeeraddr_raw(peer_addr_raw, peer_addr6_raw) == SLS_OK) {
+            bool address_matched = false;
+            for (sls_ip_access_t &acl_entry : ca->ip_actions.play) {
+                if (acl_entry.ip_address == peer_addr_raw || acl_entry.ip_address == 0) {
+                    switch (acl_entry.action) {
+                    case sls_access_action::ACCEPT:
+                        address_matched = true;
+                        spdlog::info("[{}] CSLSListener::handler Accepted connection from {}:{:d} for app '{}'",
+                                     fmt::ptr(this), peer_name, peer_port, ca->app_publisher);
+                        break;
+                    case sls_access_action::DENY:
+                        spdlog::warn("[{}] CSLSListener::handler Rejected connection from {}:{:d} for app '{}'",
+                                     fmt::ptr(this), peer_name, peer_port, ca->app_publisher);
+                        srt->libsrt_close();
+                        delete srt;
+                        return client_count;
+                    default:
+                        spdlog::error("[{}] CSLSListener::handler Unknown action [sls_access_action={:d}], ignoring",
+                                      fmt::ptr(this), (int)acl_entry.action);
+                    }
+                }
+                if (address_matched) break;
+            }
+            if (!address_matched) {
+                spdlog::info("[{}] CSLSListener::handler Accepted connection from {}:{:d} for app '{}' by default",
+                             fmt::ptr(this), peer_name, peer_port, ca->app_publisher);
+            }
+        } else {
+            spdlog::error("[{}] CSLSListener::handler ACL check failed: could not get peer address", fmt::ptr(this));
+            spdlog::error("[{}] CSLSListener::handler Rejecting connection by default", fmt::ptr(this));
+            srt->libsrt_close();
+            delete srt;
+            return client_count;
+        }
+    }
+
+    CSLSRole *pub_check = m_map_publisher->get_publisher(key_stream_name);
+    if (NULL == pub_check) {
+        spdlog::error("[{}] CSLSListener::handler, refused, new role[{}:{:d}], stream={}, publisher no longer exists.",
+                      fmt::ptr(this), peer_name, peer_port, key_stream_name);
+        srt->libsrt_close();
+        delete srt;
+        return client_count;
+    }
+
+    {
+        int effective_max_players = ca->max_players_per_stream;
+        bool using_override = false;
+        auto now_ts = std::chrono::steady_clock::now();
+
+        auto it_stream_cap = m_stream_player_limit_map.find(std::string(key_stream_name));
+        if (it_stream_cap != m_stream_player_limit_map.end()) {
+            const StreamPlayerLimitEntry &sentry = it_stream_cap->second;
+            if (sentry.has_override && now_ts < sentry.expiry_time) {
+                effective_max_players = sentry.max_players_per_stream;
+                using_override = true;
+            } else if (now_ts >= sentry.expiry_time) {
+                m_stream_player_limit_map.erase(it_stream_cap);
+            }
+        }
+
+        if (!using_override && player_key_validation_required) {
+            PlayerKeyCacheEntry entry;
+            bool found_entry = false;
+            {
+                std::lock_guard<std::mutex> lk(m_cache_mutex);
+                auto it_cache = m_player_key_cache.find(player_key);
+                if (it_cache != m_player_key_cache.end()) {
+                    entry = it_cache->second;
+                    found_entry = true;
+                }
+            }
+            if (found_entry) {
+                if (entry.is_valid && now_ts < entry.expiry_time && entry.has_max_players_override) {
+                    effective_max_players = entry.max_players_per_stream_override;
+                    using_override = true;
+                }
+            }
+        }
+
+        if (effective_max_players > 0) {
+            int current_player_count = m_list_role->count_players_for_stream(key_stream_name);
+            if (current_player_count >= effective_max_players) {
+                spdlog::warn("[{}] CSLSListener::handler, refused, new player[{}:{:d}], stream={}, player limit reached ({:d}/{:d}){}.",
+                             fmt::ptr(this), peer_name, peer_port, key_stream_name, current_player_count, effective_max_players,
+                             using_override ? " [override]" : "");
+                srt->libsrt_close();
+                delete srt;
+                return client_count;
+            }
+            spdlog::debug("[{}] CSLSListener::handler, new player[{}:{:d}], stream={}, player count ({:d}/{:d}){}.",
+                          fmt::ptr(this), peer_name, peer_port, key_stream_name, current_player_count, effective_max_players,
+                          using_override ? " [override]" : "");
+        }
+    }
+
+    if (srt->libsrt_socket_nonblock(0) < 0)
+        spdlog::warn("[{}] CSLSListener::handler, new player[{}:{:d}], libsrt_socket_nonblock failed.",
+                     fmt::ptr(this), peer_name, peer_port);
+
+    CSLSPlayer *player = new CSLSPlayer;
+    if (NULL == player) {
+        spdlog::error("[{}] CSLSListener::handler, failed to allocate player for [{}:{:d}]",
+                     fmt::ptr(this), peer_name, peer_port);
+        srt->libsrt_close();
+        delete srt;
+        return client_count;
+    }
+
+    player->init();
+    player->set_idle_streams_timeout(m_idle_streams_timeout_role);
+    player->set_srt(srt);
+    player->set_map_data(key_stream_name, m_map_data);
+    player->set_latency(final_latency);
+    // Seed the role's streamid with the (possibly player-key-resolved) sid
+    // so downstream hooks like on_event_url report the real stream instead
+    // of the raw SRTO_STREAMID the client sent.
+    player->set_streamid(effective_sid.c_str());
+
+    stat_info_t *stat_info_obj = new stat_info_t();
+    stat_info_obj->port = m_port;
+    stat_info_obj->role = player->get_role_name();
+    stat_info_obj->pub_domain_app = app_uplive;
+    stat_info_obj->stream_name = stream_name;
+    stat_info_obj->url = effective_sid;
+    stat_info_obj->remote_ip = peer_name;
+    stat_info_obj->remote_port = peer_port;
+    stat_info_obj->start_time = cur_time;
+    player->set_stat_info_base(*stat_info_obj);
+
+    player->set_http_url(m_http_url_role);
+    player->on_connect();
+
+    m_list_role->push(player);
+    spdlog::info("[{}] CSLSListener::handler, new player[{}] =[{}:{:d}], key_stream_name={}, {}={}, m_list_role->size={:d}.",
+                 fmt::ptr(this), fmt::ptr(player), peer_name, peer_port, key_stream_name, player->get_role_name(), fmt::ptr(player), m_list_role->size());
+    return client_count;
+}
+
+void CSLSListener::on_worker_tick()
+{
+    cleanupExpiredStreamOverrides();
+    sweep_player_key_cache();
+    // Fold completed async player-key webhooks into the cache, then advance
+    // any connections held open waiting on those results.
+    drain_player_key_validations();
+    drive_pending_player_connections();
+}
+
+void CSLSListener::drive_pending_player_connections()
+{
+    if (m_pending_player_connections.empty())
+        return;
+
+    auto now = std::chrono::steady_clock::now();
+    for (auto it = m_pending_player_connections.begin(); it != m_pending_player_connections.end();) {
+        bool found = false;
+        bool valid = false;
+        std::string resolved;
+        {
+            std::lock_guard<std::mutex> lk(m_cache_mutex);
+            auto c = m_player_key_cache.find(it->player_key);
+            if (c != m_player_key_cache.end() && now < c->second.expiry_time) {
+                found = true;
+                valid = c->second.is_valid;
+                resolved = c->second.resolved_stream_id;
+            }
+        }
+
+        if (found && valid) {
+            // Parse and safety-check the resolved stream id, mirroring the
+            // synchronous post-validation path, then complete the accept.
+            char resolved_buf[1024] = {0};
+            strlcpy(resolved_buf, resolved.c_str(), sizeof(resolved_buf));
+            std::map<std::string, std::string> kv = it->srt->libsrt_parse_sid(resolved_buf);
+            if (kv.count("h") && kv.count("sls_app") && kv.count("r") &&
+                sls_is_safe_name(kv.at("h").c_str()) &&
+                sls_is_safe_name(kv.at("sls_app").c_str()) &&
+                sls_is_safe_name(kv.at("r").c_str())) {
+                finish_player_accept(it->srt, it->app_uplive, kv.at("r"), resolved,
+                                     it->player_key, true,
+                                     it->peer_name.c_str(), it->peer_port,
+                                     it->final_latency, it->session_id, it->cur_time);
+            } else {
+                spdlog::error("[connection:{}] deferred player accept: resolved stream_id '{}' invalid for key='{}', closing.",
+                             it->session_id, resolved, it->player_key);
+                it->srt->libsrt_close();
+                delete it->srt;
+            }
+            it = m_pending_player_connections.erase(it);
+        } else if (found && !valid) {
+            spdlog::debug("[connection:{}] deferred player accept: key='{}' rejected by auth, closing.",
+                         it->session_id, it->player_key);
+            it->srt->libsrt_close();
+            delete it->srt;
+            it = m_pending_player_connections.erase(it);
+        } else if (now >= it->deadline) {
+            spdlog::warn("[connection:{}] deferred player accept: key='{}' not resolved before deadline, closing.",
+                         it->session_id, it->player_key);
+            it->srt->libsrt_close();
+            delete it->srt;
+            it = m_pending_player_connections.erase(it);
+        } else {
+            ++it; // still waiting on the webhook result
         }
     }
 }

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -100,16 +100,30 @@ int CSLSListener::handler()
     }
 
     sls_conf_server_t* conf_server = (sls_conf_server_t*)m_conf;
+    const bool is_publisher = m_is_publisher_listener;
+    const char* role = is_publisher ? "publisher" : "player";
+
+    // The latency that governs quality differs by role, and SRTO_LATENCY's
+    // getter is just an alias for SRTO_RCVLATENCY (see srt.h). For a publisher
+    // we are the receiver, so SRTO_RCVLATENCY is the real TSBPD window that
+    // absorbs retransmits (too small => glitching on lossy links). For a player
+    // we are the sender and never receive media from them, so RCVLATENCY is
+    // meaningless; what matters is SRTO_PEERLATENCY, the floor we impose on the
+    // viewer's own receive buffer. Reading the role-appropriate field keeps the
+    // floor/ceiling checks meaningful instead of flagging players on a value
+    // that does not affect them.
+    const SRT_SOCKOPT lat_opt = is_publisher ? SRTO_RCVLATENCY : SRTO_PEERLATENCY;
+    const char* lat_opt_name = is_publisher ? "SRTO_RCVLATENCY" : "SRTO_PEERLATENCY";
+
     int negotiated_latency = 0;
     int latency_len = sizeof(negotiated_latency);
     int final_latency = 0;
 
-    if (0 != srt->libsrt_getsockopt(SRTO_LATENCY, "SRTO_LATENCY", &negotiated_latency, &latency_len)) {
+    if (0 != srt->libsrt_getsockopt(lat_opt, lat_opt_name, &negotiated_latency, &latency_len)) {
         negotiated_latency = conf_server->latency_min > 0 ? conf_server->latency_min : 120;
         spdlog::warn("[{}] CSLSListener::handler, [{}:{:d}], failed to read latency, using fallback {} ms.",
                 fmt::ptr(this), peer_name, peer_port, negotiated_latency);
     } else {
-        const char* role = m_is_publisher_listener ? "publisher" : "player";
         // Log latency at DEBUG level
         if (sls_should_log_category(SLSLogCategory::CONNECTION, spdlog::level::debug))
         {
@@ -128,14 +142,22 @@ int CSLSListener::handler()
     final_latency = negotiated_latency;
 
     // A connection landing below latency_min means the listener floor
-    // (SRTO_LATENCY/RCVLATENCY set in CSLSListener::start) did not reach
-    // this socket. Warn rather than silently run a too-tight TSBPD window.
+    // (SRTO_LATENCY/RCVLATENCY/PEERLATENCY set in CSLSListener::start) did not
+    // win the handshake negotiation for this peer. Our pre-bind floor should
+    // force effective = max(our_floor, peer_proposed), so a sub-floor result is
+    // peer-dependent: certain (often older/HSv4) SRT senders negotiate it down.
+    // We cannot raise it post-accept (RCVLATENCY is a pre-connect option), so
+    // capture the peer's SRT version here to identify the offending clients.
     if (conf_server->latency_min > 0 && negotiated_latency > 0 &&
         negotiated_latency < conf_server->latency_min)
     {
-        spdlog::warn("[connection:{}] {} {}:{} negotiated latency {} ms below latency_min {} ms.",
-                     session_id, m_is_publisher_listener ? "publisher" : "player",
-                     peer_name, peer_port, negotiated_latency, conf_server->latency_min);
+        int peer_version = 0;
+        int peer_version_len = sizeof(peer_version);
+        srt->libsrt_getsockopt(SRTO_PEERVERSION, "SRTO_PEERVERSION",
+                               &peer_version, &peer_version_len);
+        spdlog::warn("[connection:{}] {} {}:{} negotiated {} {} ms below latency_min {} ms (peer SRT version {:#x}).",
+                     session_id, role, peer_name, peer_port, lat_opt_name,
+                     negotiated_latency, conf_server->latency_min, peer_version);
     }
 
     if (0 != srt->libsrt_getsockopt(SRTO_STREAMID, "SRTO_STREAMID", &sid, &sid_size)) {

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -17,6 +17,7 @@
 int CSLSListener::handler()
 {
     cleanupExpiredStreamOverrides();
+    sweep_player_key_cache();
     int ret = SLS_OK;
     int fd_client = 0;
     CSLSSrt *srt = NULL;

--- a/src/core/SLSListenerHandler.cpp
+++ b/src/core/SLSListenerHandler.cpp
@@ -268,6 +268,13 @@ int CSLSListener::handler()
     }
     free(sid_copy);
 
+    // strtok keeps any stray whitespace/newline a client tacked onto the
+    // streamid, which would break the m_domain_players/m_app_players matches
+    // below and the player_key sent to the auth URL. Trim before they're used.
+    strlcpy(domain, sls_trim(domain).c_str(), sizeof(domain));
+    strlcpy(app, sls_trim(app).c_str(), sizeof(app));
+    strlcpy(stream_part, sls_trim(stream_part).c_str(), sizeof(stream_part));
+
     bool is_player_domain = false;
     bool is_player_app = false;
 

--- a/src/core/SLSManager.cpp
+++ b/src/core/SLSManager.cpp
@@ -35,6 +35,7 @@ using json = nlohmann::json;
 #include "SLSLog.hpp"
 #include "SLSListener.hpp"
 #include "SLSPublisher.hpp"
+#include "auth_reject_cache.hpp"
 
 /**
  * srt conf
@@ -150,6 +151,11 @@ int CSLSManager::start()
     m_list_role = new CSLSRoleList;
     spdlog::info("[{}] CSLSManager::start, new m_list_role={}.", fmt::ptr(this), fmt::ptr(m_list_role));
 
+    // One negative-auth cache shared across all listeners and roles. TTL is
+    // applied per publisher listener from its conf in init_conf_app; default
+    // 30s until then.
+    m_auth_reject_cache = std::make_shared<AuthRejectCache>();
+
     //create listeners according config, delete by groups
     for (i = 0; i < m_server_count; i++)
     {
@@ -167,6 +173,7 @@ int CSLSManager::start()
         auto make_listener = [&](int port, bool is_publisher, bool srtla, bool legacy) -> CSLSListener * {
             CSLSListener *l = new CSLSListener(); //deleted by groups
             l->set_role_list(m_list_role);
+            l->set_auth_reject_cache(m_auth_reject_cache);
             l->set_conf((sls_conf_base_t *)conf);
             l->set_map_data("", &m_map_data[i]);
             l->set_map_publisher(&m_map_publisher[i]);

--- a/src/core/SLSManager.hpp
+++ b/src/core/SLSManager.hpp
@@ -141,4 +141,9 @@ private:
 
     CSLSRoleList *m_list_role;
     CSLSGroup *m_single_group;
+
+    // Process-wide negative-auth cache, shared (by shared_ptr) with every
+    // publisher listener and the roles they create. Held here so it outlives
+    // any listener whose handshake callback still references it via .get().
+    std::shared_ptr<AuthRejectCache> m_auth_reject_cache;
 };

--- a/src/core/SLSRole.cpp
+++ b/src/core/SLSRole.cpp
@@ -36,6 +36,7 @@
 #include "SLSPushUrlValidator.hpp"
 #include "util.hpp"
 #include "SLSBitrateLimit.hpp"
+#include "auth_reject_cache.hpp"
 
 /**
  * CSLSRole class implementation
@@ -683,6 +684,11 @@ void CSLSRole::set_http_url(const char *http_url)
     m_http_passed = false;
 }
 
+void CSLSRole::set_auth_reject_cache(std::shared_ptr<AuthRejectCache> cache)
+{
+    m_auth_reject_cache = std::move(cache);
+}
+
 int CSLSRole::on_connect()
 {
     if (strlen(m_http_url) == 0)
@@ -745,6 +751,12 @@ int CSLSRole::check_http_passed()
     if (!response.success || response.status_code != 200) {
         spdlog::error("[{}] CSLSRole::check_http_client_response, http refused, invalid {} http_url='{}', status={}, error='{}'.",
                       fmt::ptr(this), m_role_name, m_http_url, response.status_code, response.error);
+        // Negative-cache the streamid so a rotating client hammering the same
+        // bad key is rejected at the next handshake (no accept, no webhook).
+        // Only publisher roles carry a cache; key on the raw streamid the
+        // listener callback also sees so the lookup matches the insert.
+        if (m_auth_reject_cache)
+            m_auth_reject_cache->record_failure(get_streamid());
         invalid_srt();
         return SLS_ERROR;
     }

--- a/src/core/SLSRole.cpp
+++ b/src/core/SLSRole.cpp
@@ -755,7 +755,14 @@ int CSLSRole::check_http_passed()
         // bad key is rejected at the next handshake (no accept, no webhook).
         // Only publisher roles carry a cache; key on the raw streamid the
         // listener callback also sees so the lookup matches the insert.
-        if (m_auth_reject_cache)
+        //
+        // Only cache on an explicit auth-reject status (401/403): the key
+        // itself is bad, so blocking its repeats is correct. A transport
+        // failure (response.success == false) or a 5xx is the *backend*
+        // faltering, not the key, and caching those would lock a legitimate
+        // publisher out for the whole TTL on a single backend hiccup.
+        if (m_auth_reject_cache && response.success &&
+            (response.status_code == 401 || response.status_code == 403))
             m_auth_reject_cache->record_failure(get_streamid());
         invalid_srt();
         return SLS_ERROR;

--- a/src/core/SLSRole.cpp
+++ b/src/core/SLSRole.cpp
@@ -255,6 +255,29 @@ int CSLSRole::remove_from_epoll()
     return ret;
 }
 
+int CSLSRole::set_epoll_out(bool enable)
+{
+    if (NULL == m_srt)
+        return SLS_ERROR;
+    if (enable == m_epoll_out_armed)
+        return SLS_OK;
+    int ret = m_srt->libsrt_arm_epoll_out(enable);
+    if (SLS_OK == ret)
+        m_epoll_out_armed = enable;
+    return ret;
+}
+
+void CSLSRole::update_egress_arming()
+{
+    if (!m_is_write)
+        return;
+    // Staged data we couldn't fully send (m_data_pos < m_data_len) means
+    // the SRT send buffer is backpressured; arm OUT so libsrt wakes the
+    // worker when it drains. Otherwise we are caught up — disarm so the
+    // always-writable socket doesn't busy-return from srt_epoll_wait.
+    set_epoll_out(m_data_pos < m_data_len);
+}
+
 int CSLSRole::get_sock_state()
 {
     if (m_srt)
@@ -442,7 +465,6 @@ int CSLSRole::get_uptime() {
 
 int CSLSRole::handler_write_data()
 {
-    int ret = 0;
     int write_size = 0;
 
     if (check_http_passed())
@@ -472,129 +494,160 @@ int CSLSRole::handler_write_data()
         return SLS_ERROR;
     }
 
-    if (m_data_len < TS_UDP_LEN)
+    // Drain up to MAX_EGRESS_BATCHES publisher-ring batches per call.
+    // Egress is driven by the worker's periodic pass rather than a
+    // permanently-armed SRT_EPOLL_OUT, so this inner loop is what stops
+    // throughput being capped at one DATA_BUFF_SIZE per worker wakeup: a
+    // viewer that fell behind can pull several batches here before the
+    // worker moves on to the publisher read and the other roles. We stop
+    // early the moment the ring has no more data (get() returns 0) or the
+    // socket backpressures (EASYNCSND).
+    for (int batch = 0; batch < MAX_EGRESS_BATCHES; ++batch)
     {
-        ret = m_map_data->get(m_map_data_key, m_data, DATA_BUFF_SIZE, &m_map_data_id, TS_UDP_LEN);
-        if (ret < 0)
-        {
-            //maybe no publisher, wait for timeout.
-            return SLS_OK;
-        }
-        m_data_pos = 0;
-        m_data_len = ret;
-    }
-
-    m_stat_bitrate_datacount += ret;
-    //update invalid begin time
-    m_invalid_begin_tm = sls_gettime_ms();
-    int d = m_invalid_begin_tm - m_stat_bitrate_last_tm;
-    if (d >= m_stat_bitrate_interval)
-    {
-        m_kbitrate = m_stat_bitrate_datacount * 8 / d;
-        m_stat_bitrate_datacount = 0;
-        m_stat_bitrate_last_tm = m_invalid_begin_tm;
-    }
-
-    int len = m_data_len - m_data_pos;
-    int remainer = m_data_len - m_data_pos;
-    while (remainer >= TS_UDP_LEN)
-    {
-        // Re-check m_srt before each write in case it was closed mid-operation
+        // Re-check m_srt before fetching / writing in case it was closed
+        // mid-operation (e.g. invalidated by another path this cycle).
         if (NULL == m_srt)
         {
-            spdlog::error("[{}] CSLSRole::handler_write_data, m_srt became NULL during write loop.",
+            spdlog::error("[{}] CSLSRole::handler_write_data, m_srt became NULL during drain loop.",
                           fmt::ptr(this));
             return SLS_ERROR;
         }
 
-        ret = write(m_data + m_data_pos, TS_UDP_LEN);
-        if (ret < TS_UDP_LEN)
+        if (m_data_len < TS_UDP_LEN)
         {
-            // Distinguish transient backpressure (SRT_EASYNCSND, errno
-            // 6001) from real failures. EASYNCSND means the per-socket
-            // SRT send buffer is momentarily full and the write should
-            // be retried on the next SRT_EPOLL_OUT wake. Treating it as
-            // fatal (the old behaviour) silently disconnected any
-            // viewer that hit a brief congestion event on their link.
-            // Leaving m_data_pos/m_data_len intact so the next handler
-            // call resumes from the same offset.
-            if (ret < 0)
+            int got = m_map_data->get(m_map_data_key, m_data, DATA_BUFF_SIZE, &m_map_data_id, TS_UDP_LEN);
+            if (got < 0)
             {
-                int err_no = CSLSSrt::libsrt_lasterror();
-                if (err_no == SRT_EASYNCSND)
-                {
-                    m_send_backpressure_count.fetch_add(1, std::memory_order_relaxed);
+                //maybe no publisher, wait for timeout.
+                break;
+            }
+            if (got == 0)
+            {
+                // No new data yet (caught up to the write head, first-call
+                // priming, or an overrun resync). Nothing more to drain.
+                break;
+            }
+            m_data_pos = 0;
+            m_data_len = got;
 
-                    // Stuck-viewer detection. The per-packet success
-                    // path above has already reset m_backpressure_stuck_since_ms
-                    // to 0 on any progress made earlier in this call, so
-                    // observing it == 0 here means this is the first
-                    // EASYNCSND of a fresh stuck streak; start the timer.
-                    // If it was already non-zero, the stuck streak is
-                    // ongoing — kick the viewer if it has exceeded the
-                    // timeout. Continuous zero-progress backpressure
-                    // means the viewer's link cannot sustain the stream
-                    // and they would otherwise hold a publisher-ring
-                    // read position open indefinitely.
-                    int64_t stuck_timeout_ms = backpressure_stuck_timeout_ms();
-                    if (m_backpressure_stuck_since_ms == 0)
-                    {
-                        m_backpressure_stuck_since_ms = m_invalid_begin_tm;
-                    }
-                    else if ((m_invalid_begin_tm - m_backpressure_stuck_since_ms)
-                             > stuck_timeout_ms)
-                    {
-                        spdlog::warn("[{}] CSLSRole::handler_write_data, viewer stuck in backpressure {} ms (>{}ms, latency={}ms), disconnecting. backpressureEvents={}.",
-                                     fmt::ptr(this),
-                                     (long long)(m_invalid_begin_tm - m_backpressure_stuck_since_ms),
-                                     (long long)stuck_timeout_ms,
-                                     m_latency,
-                                     m_send_backpressure_count.load(std::memory_order_relaxed));
-                        return SLS_ERROR;
-                    }
+            m_stat_bitrate_datacount += got;
+            //update invalid begin time
+            m_invalid_begin_tm = sls_gettime_ms();
+            int d = m_invalid_begin_tm - m_stat_bitrate_last_tm;
+            if (d >= m_stat_bitrate_interval)
+            {
+                m_kbitrate = m_stat_bitrate_datacount * 8 / d;
+                m_stat_bitrate_datacount = 0;
+                m_stat_bitrate_last_tm = m_invalid_begin_tm;
+            }
+        }
 
-                    spdlog::trace("[{}] CSLSRole::handler_write_data, backpressure, pos={:d}, remaining={:d}.",
-                                  fmt::ptr(this), m_data_pos, remainer);
-                    return write_size;
-                }
-                spdlog::error("[{}] CSLSRole::handler_write_data, write data failed, len={:d}, ret={:d}, errno={:d}, not {:d}.",
-                              fmt::ptr(this), len, ret, err_no, TS_UDP_LEN);
-                spdlog::error("[{}] CSLSRole::handler_write_data, critical write failure (ret={:d}, errno={:d}), marking connection invalid.",
-                              fmt::ptr(this), ret, err_no);
+        int len = m_data_len - m_data_pos;
+        int remainer = m_data_len - m_data_pos;
+        while (remainer >= TS_UDP_LEN)
+        {
+            // Re-check m_srt before each write in case it was closed mid-operation
+            if (NULL == m_srt)
+            {
+                spdlog::error("[{}] CSLSRole::handler_write_data, m_srt became NULL during write loop.",
+                              fmt::ptr(this));
                 return SLS_ERROR;
             }
-            // Partial write (0 < ret < TS_UDP_LEN). SRT message API is
-            // all-or-nothing per message so this branch is unexpected;
-            // log and break to surface the anomaly without killing the
-            // connection.
-            spdlog::error("[{}] CSLSRole::handler_write_data, short write, len={:d}, ret={:d}, not {:d}.",
-                          fmt::ptr(this), len, ret, TS_UDP_LEN);
-            break;
-        }
-        m_data_pos += TS_UDP_LEN;
-        write_size += TS_UDP_LEN;
-        // Any successful write counts as progress and clears the
-        // stuck-since marker — a viewer who can drain even slowly is
-        // not zombie-stuck, just slow. Cheap to do per packet; field
-        // is not shared across threads.
-        m_backpressure_stuck_since_ms = 0;
-        remainer = m_data_len - m_data_pos;
-    }
 
-    if (m_data_pos < m_data_len)
-    {
-        spdlog::trace("[{}] CSLSRole::handler_write_data, write data, len={:d}, remainder={:d}.", fmt::ptr(this), len, m_data_len - m_data_pos);
-        return SLS_OK;
+            int ret = write(m_data + m_data_pos, TS_UDP_LEN);
+            if (ret < TS_UDP_LEN)
+            {
+                // Distinguish transient backpressure (SRT_EASYNCSND, errno
+                // 6001) from real failures. EASYNCSND means the per-socket
+                // SRT send buffer is momentarily full and the write should
+                // be retried on the next SRT_EPOLL_OUT wake (the worker
+                // arms OUT via update_egress_arming once we return with
+                // m_data_pos < m_data_len). Treating it as fatal (the old
+                // behaviour) silently disconnected any viewer that hit a
+                // brief congestion event on their link. Leaving
+                // m_data_pos/m_data_len intact so the next handler call
+                // resumes from the same offset.
+                if (ret < 0)
+                {
+                    int err_no = CSLSSrt::libsrt_lasterror();
+                    if (err_no == SRT_EASYNCSND)
+                    {
+                        m_send_backpressure_count.fetch_add(1, std::memory_order_relaxed);
+
+                        // Stuck-viewer detection. The per-packet success
+                        // path above has already reset m_backpressure_stuck_since_ms
+                        // to 0 on any progress made earlier in this call, so
+                        // observing it == 0 here means this is the first
+                        // EASYNCSND of a fresh stuck streak; start the timer.
+                        // If it was already non-zero, the stuck streak is
+                        // ongoing — kick the viewer if it has exceeded the
+                        // timeout. Continuous zero-progress backpressure
+                        // means the viewer's link cannot sustain the stream
+                        // and they would otherwise hold a publisher-ring
+                        // read position open indefinitely.
+                        int64_t stuck_timeout_ms = backpressure_stuck_timeout_ms();
+                        if (m_backpressure_stuck_since_ms == 0)
+                        {
+                            m_backpressure_stuck_since_ms = sls_gettime_ms();
+                        }
+                        else if ((sls_gettime_ms() - m_backpressure_stuck_since_ms)
+                                 > stuck_timeout_ms)
+                        {
+                            spdlog::warn("[{}] CSLSRole::handler_write_data, viewer stuck in backpressure {} ms (>{}ms, latency={}ms), disconnecting. backpressureEvents={}.",
+                                         fmt::ptr(this),
+                                         (long long)(sls_gettime_ms() - m_backpressure_stuck_since_ms),
+                                         (long long)stuck_timeout_ms,
+                                         m_latency,
+                                         m_send_backpressure_count.load(std::memory_order_relaxed));
+                            return SLS_ERROR;
+                        }
+
+                        spdlog::trace("[{}] CSLSRole::handler_write_data, backpressure, pos={:d}, remaining={:d}.",
+                                      fmt::ptr(this), m_data_pos, remainer);
+                        return write_size;
+                    }
+                    spdlog::error("[{}] CSLSRole::handler_write_data, write data failed, len={:d}, ret={:d}, errno={:d}, not {:d}.",
+                                  fmt::ptr(this), len, ret, err_no, TS_UDP_LEN);
+                    spdlog::error("[{}] CSLSRole::handler_write_data, critical write failure (ret={:d}, errno={:d}), marking connection invalid.",
+                                  fmt::ptr(this), ret, err_no);
+                    return SLS_ERROR;
+                }
+                // Partial write (0 < ret < TS_UDP_LEN). SRT message API is
+                // all-or-nothing per message so this branch is unexpected;
+                // log and break to surface the anomaly without killing the
+                // connection.
+                spdlog::error("[{}] CSLSRole::handler_write_data, short write, len={:d}, ret={:d}, not {:d}.",
+                              fmt::ptr(this), len, ret, TS_UDP_LEN);
+                break;
+            }
+            m_data_pos += TS_UDP_LEN;
+            write_size += TS_UDP_LEN;
+            // Any successful write counts as progress and clears the
+            // stuck-since marker — a viewer who can drain even slowly is
+            // not zombie-stuck, just slow. Cheap to do per packet; field
+            // is not shared across threads.
+            m_backpressure_stuck_since_ms = 0;
+            remainer = m_data_len - m_data_pos;
+        }
+
+        if (m_data_pos > m_data_len)
+        {
+            spdlog::error("[{}] CSLSRole::handler_write_data, write data, data error, len={:d}, m_data_pos={:d} > m_data_len={:d}.", fmt::ptr(this), len, m_data_pos, m_data_len);
+        }
+
+        if (m_data_pos < m_data_len)
+        {
+            // Staged batch not fully flushed (only reachable via the
+            // unexpected short-write path; EASYNCSND already returned
+            // above). Preserve the offset and stop — the worker arms OUT
+            // and we resume next cycle.
+            spdlog::trace("[{}] CSLSRole::handler_write_data, write data, len={:d}, remainder={:d}.", fmt::ptr(this), len, m_data_len - m_data_pos);
+            return write_size;
+        }
+
+        // Batch fully sent — reset and loop to drain the next one.
+        m_data_pos = m_data_len = 0;
     }
-    if (m_data_pos > m_data_len)
-    {
-        spdlog::error("[{}] CSLSRole::handler_write_data, write data, data error, len={:d}, m_data_pos={:d} > m_data_len={:d}.", fmt::ptr(this), len, m_data_pos, m_data_len);
-    }
-    else
-    {
-        //spdlog::trace("[{}] CSLSRole::handler_write_data, write data, m_data_len={:d}.", fmt::ptr(this), m_data_len);
-    }
-    m_data_pos = m_data_len = 0;
 
     return write_size;
 }

--- a/src/core/SLSRole.cpp
+++ b/src/core/SLSRole.cpp
@@ -132,10 +132,27 @@ int CSLSRole::invalid_srt()
     return SLS_OK;
 }
 
+void CSLSRole::request_kick()
+{
+    m_kick_requested.store(true, std::memory_order_relaxed);
+}
+
 int CSLSRole::get_state(int64_t cur_time_ms)
 {
     if (SLS_RS_INVALID == m_state)
         return m_state;
+
+    // Honour a cross-thread kick (publisher takeover). Doing the teardown
+    // here keeps invalid_srt() on the socket-owning worker, so it can't race
+    // a concurrent handler() read on the same CSLSSrt.
+    if (m_kick_requested.load(std::memory_order_relaxed))
+    {
+        spdlog::info("[{}] CSLSRole::get_state, kick requested for {}, fd={:d}, call invalid_srt.",
+                     fmt::ptr(this), m_role_name, get_fd());
+        m_state = SLS_RS_INVALID;
+        invalid_srt();
+        return m_state;
+    }
 
     if (check_idle_streams_duration(cur_time_ms))
     {

--- a/src/core/SLSRole.hpp
+++ b/src/core/SLSRole.hpp
@@ -40,6 +40,8 @@
 #include <atomic>
 #include "SLSBitrateLimit.hpp"
 
+class AuthRejectCache;
+
 enum SLS_ROLE_STATE
 {
     SLS_RS_UNINIT = 0,
@@ -135,6 +137,10 @@ public:
     virtual int get_peer_info(char *peer_name, int &peer_port);
 
     void set_http_url(const char *http_url);
+    // Inject the shared negative-auth cache. Only publisher roles receive a
+    // non-null cache; check_http_passed records a failed key here so the
+    // listener callback can reject its repeats at the next handshake.
+    void set_auth_reject_cache(std::shared_ptr<AuthRejectCache> cache);
     int on_connect();
     int on_close();
     // Push destinations harvested from the publish-auth webhook response.
@@ -267,6 +273,9 @@ protected:
 
     // Push destinations from publish-auth webhook (publisher roles only).
     std::vector<std::string> m_push_urls;
+
+    // Shared negative-auth cache (publisher roles only; null otherwise).
+    std::shared_ptr<AuthRejectCache> m_auth_reject_cache;
 
     int handler_write_data();
     int handler_read_data(int64_t *last_read_time = NULL);

--- a/src/core/SLSRole.hpp
+++ b/src/core/SLSRole.hpp
@@ -82,6 +82,12 @@ public:
     virtual int init();
     virtual int uninit();
     virtual int handler();
+    // Periodic hook run by the worker on every role in its map once per loop
+    // pass (~POLLING_TIME), independent of socket events. Default no-op;
+    // CSLSListener overrides it to advance work that must progress without a
+    // new connection event (draining async player-key validations and
+    // completing deferred player accepts). Runs on the owning worker thread.
+    virtual void on_worker_tick() {}
 
     int open(char *url);
     int close();

--- a/src/core/SLSRole.hpp
+++ b/src/core/SLSRole.hpp
@@ -59,6 +59,15 @@ enum SLS_ROLE_STATE
 // 100-viewer node is ~11 MB (was ~13 MB of static role buffer space).
 const int DATA_BUFF_SIZE = 16 * 1316;
 const int UNLIMITED_TIMEOUT = -1;
+
+// Max publisher-ring batches drained per handler_write_data() call.
+// Egress is driven by the worker's periodic pass (players are no longer
+// permanently armed for SRT_EPOLL_OUT), so without an inner drain loop
+// throughput would be capped at one DATA_BUFF_SIZE per worker wakeup.
+// 8 * DATA_BUFF_SIZE (~168 KB) per call lets a catching-up viewer pull a
+// large backlog quickly while still bounding how long one role holds the
+// worker before it yields to the publisher read and the other roles.
+const int MAX_EGRESS_BATCHES = 8;
 /**
  * CSLSRole , the base of player, publisher and listener
  */
@@ -86,6 +95,13 @@ public:
 
     int add_to_epoll(int eid);
     int remove_from_epoll();
+    // Reconcile this writable role's SRT_EPOLL_OUT arm state with whether
+    // it still has staged egress data it could not fully send. Called by
+    // the worker after each egress attempt: arms OUT while backpressured
+    // (so the worker wakes when the send buffer drains) and disarms once
+    // caught up (so an idle writable socket does not busy-return). No-op
+    // for read roles. Only issues a syscall on an actual state change.
+    void update_egress_arming();
     int get_state(int64_t cur_time_microsec = 0);
     int get_sock_state();
     char *get_role_name();
@@ -207,6 +223,16 @@ protected:
     // stream) instead of holding their publisher-ring read position
     // open indefinitely.
     int64_t m_backpressure_stuck_since_ms{0};
+
+    // Whether SRT_EPOLL_OUT is currently armed on this writable role's
+    // socket. Writable roles register ERR-only (see libsrt_add_to_epoll);
+    // OUT is toggled on demand by update_egress_arming() so we only pay
+    // the srt_epoll_update_usock syscall when the backpressure state
+    // actually flips. Touched only from the owning worker thread.
+    bool m_epoll_out_armed{false};
+    // Arms/disarms SRT_EPOLL_OUT, updating m_epoll_out_armed. Returns
+    // early without a syscall when already in the requested state.
+    int set_epoll_out(bool enable);
 
     // Floor below which the stuck-viewer timeout will never drop. Even
     // at very low negotiated latency (e.g. 20ms), 500ms gives genuine

--- a/src/core/SLSRole.hpp
+++ b/src/core/SLSRole.hpp
@@ -37,6 +37,7 @@
 #include "AsyncHttpClient.hpp"
 #include <future>
 #include <memory>
+#include <atomic>
 #include "SLSBitrateLimit.hpp"
 
 enum SLS_ROLE_STATE
@@ -88,6 +89,13 @@ public:
     int get_state(int64_t cur_time_microsec = 0);
     int get_sock_state();
     char *get_role_name();
+
+    // Ask the owning worker to tear this role down on its next state check.
+    // Safe to call from another thread (the listener uses it for publisher
+    // takeover): it only flips an atomic flag. The actual invalid_srt() and
+    // map cleanup still run on the worker that owns the SRT socket, via
+    // get_state(), so we never race a concurrent handler() on the same socket.
+    void request_kick();
 
     void set_conf(sls_conf_base_t *conf);
     void set_map_data(const char *map_key, CSLSMapData *map_data);
@@ -162,6 +170,10 @@ protected:
     int m_latency;              //ms
 
     int m_state;
+    // Cross-thread teardown request set by request_kick(). Observed by
+    // get_state() on the owning worker. Atomic so the listener thread can
+    // signal a takeover without locking the socket hot path.
+    std::atomic<bool> m_kick_requested{false};
     int m_back_log; //maximum number of connections at the same time
     int m_port;
     char m_peer_ip[IP_MAX_LEN];

--- a/src/core/SLSSrt.cpp
+++ b/src/core/SLSSrt.cpp
@@ -33,6 +33,7 @@
 #include "SLSLog.hpp"
 #include "SLSLock.hpp"
 #include "util.hpp"
+#include "sls_sid.hpp"
 
 /**
  * CSLSSrt class implementation
@@ -388,8 +389,8 @@ int CSLSSrt::libsrt_listen(int backlog)
     return SLS_OK;
 }
 
-int CSLSSrt::libsrt_set_listen_callback(srt_listen_callback_fn * listen_callback_fn) {
-    int ret = srt_listen_callback(m_sc.fd, listen_callback_fn, NULL);
+int CSLSSrt::libsrt_set_listen_callback(srt_listen_callback_fn * listen_callback_fn, void *opaque) {
+    int ret = srt_listen_callback(m_sc.fd, listen_callback_fn, opaque);
     if (ret) {
         return SLS_ERROR;
     }
@@ -474,36 +475,9 @@ int CSLSSrt::libsrt_socket_nonblock(int enable)
 
 std::map<std::string, std::string> CSLSSrt::libsrt_parse_sid(char *sid)
 {
-    static const char stdhdr[] = "#!::";
-    uint32_t *pattern = (uint32_t *)stdhdr;
-    std::map<std::string, std::string> ret;
-    if (strlen(sid) > 4 && *(uint32_t *)sid == *pattern)
-    {
-        std::vector<string> items;
-        sls_split_string(sid + 4, ",", items);
-        for (auto &i : items)
-        {
-            std::vector<string> kv;
-            sls_split_string(i, "=", kv);
-            if (kv.size() == 2)
-            {
-
-                ret[sls_trim(kv.at(0))] = sls_trim(kv.at(1));
-            }
-        }
-    }
-    else
-    {
-        std::vector<string> items;
-        sls_split_string(sid, "/", items);
-        if (items.size() >= 3)
-        {
-            ret["h"] = sls_trim(items.at(0));
-            ret["sls_app"] = sls_trim(items.at(1));
-            ret["r"] = sls_trim(items.at(2));
-        }
-    }
-    return ret;
+    // Delegates to the free function in sls_sid so the handshake callback
+    // (no CSLSSrt instance yet) and this post-accept path parse identically.
+    return sls_parse_streamid(sid);
 }
 
 int CSLSSrt::libsrt_read(char *buf, int size)

--- a/src/core/SLSSrt.cpp
+++ b/src/core/SLSSrt.cpp
@@ -546,7 +546,6 @@ int CSLSSrt::libsrt_add_to_epoll(int eid, bool write)
 {
     int ret = SLS_OK;
     int fd = m_sc.fd;
-    int modes = write ? SRT_EPOLL_OUT : SRT_EPOLL_IN;
 
     if (!eid)
     {
@@ -554,7 +553,18 @@ int CSLSSrt::libsrt_add_to_epoll(int eid, bool write)
         return SLS_ERROR;
     }
 
-    modes |= SRT_EPOLL_ERR;
+    // Readable roles (publisher/puller) watch IN. Writable roles
+    // (player/pusher) are NOT armed for OUT at rest: SRT_EPOLL_OUT is
+    // level-triggered and a drained SRT socket is always writable, so a
+    // permanently-armed OUT makes srt_epoll_wait return on every single
+    // iteration and turns the worker into a busy-loop. Egress is instead
+    // driven by the worker's periodic pass over the publisher ring, and
+    // OUT is armed on demand (libsrt_arm_epoll_out) only while a write is
+    // backpressured. ERR is always watched so broken sockets surface.
+    int modes = SRT_EPOLL_ERR;
+    if (!write)
+        modes |= SRT_EPOLL_IN;
+
     ret = srt_epoll_add_usock(eid, fd, &modes);
     if (ret < 0)
     {
@@ -563,6 +573,26 @@ int CSLSSrt::libsrt_add_to_epoll(int eid, bool write)
         return libsrt_neterrno();
     }
     return ret;
+}
+
+int CSLSSrt::libsrt_arm_epoll_out(bool enable)
+{
+    if (!m_sc.eid)
+    {
+        spdlog::error("[{}] CSLSSrt::libsrt_arm_epoll_out failed, eid not set.", fmt::ptr(this));
+        return SLS_ERROR;
+    }
+    int modes = SRT_EPOLL_ERR;
+    if (enable)
+        modes |= SRT_EPOLL_OUT;
+    int ret = srt_epoll_update_usock(m_sc.eid, m_sc.fd, &modes);
+    if (ret < 0)
+    {
+        spdlog::warn("[{}] CSLSSrt::libsrt_arm_epoll_out, srt_epoll_update_usock failed, eid={:d}, fd={:d}, enable={}.",
+                     fmt::ptr(this), m_sc.eid, m_sc.fd, enable);
+        return libsrt_neterrno();
+    }
+    return SLS_OK;
 }
 
 int CSLSSrt::libsrt_remove_from_epoll()

--- a/src/core/SLSSrt.cpp
+++ b/src/core/SLSSrt.cpp
@@ -291,6 +291,9 @@ int CSLSSrt::libsrt_setup(int port, bool srtla_patches)
         // viewer-link jitter.
         srt_setsockopt(fd, SOL_SOCKET, SRTO_LATENCY, &s->latency, sizeof(s->latency));
         srt_setsockopt(fd, SOL_SOCKET, SRTO_PEERLATENCY, &s->latency, sizeof(s->latency));
+        // SRTO_LATENCY already seeds RCVLATENCY, but set it explicitly so
+        // the receive floor for publishers doesn't depend on the alias.
+        srt_setsockopt(fd, SOL_SOCKET, SRTO_RCVLATENCY, &s->latency, sizeof(s->latency));
     }
 
     // SRTO_PEERIDLETIMEO bounds how long a connected peer may go fully silent

--- a/src/core/SLSSrt.cpp
+++ b/src/core/SLSSrt.cpp
@@ -277,23 +277,24 @@ int CSLSSrt::libsrt_setup(int port, bool srtla_patches)
        If unspecified or setting fails, system default is used. */
     if (s->latency > 0)
     {
-        // SRTO_LATENCY on a listener only seeds the SRT TSBPD RCVLATENCY
-        // for the receive direction. That clamps publishers (who send
-        // to us) but does nothing for players (who receive from us).
-        // Set SRTO_PEERLATENCY explicitly too so we commit, as sender,
-        // to at least this much queue-time before TLPKTDROP fires for
-        // any player we accept. The SRT handshake then negotiates the
+        // SRTO_RCVLATENCY is the receive-direction TSBPD floor and clamps
+        // publishers (who send to us); SRTO_PEERLATENCY is what we, as
+        // sender, commit to for players (the handshake negotiates the
         // player's effective receive latency to
-        //   max(player.RCVLATENCY, our.PEERLATENCY)
-        // which is what actually decides the SLS-to-viewer delivery
-        // window — and therefore whether srt_sendmsg flips into
-        // continuous EASYNCSND / SRTS_BROKEN under any real-world
-        // viewer-link jitter.
-        srt_setsockopt(fd, SOL_SOCKET, SRTO_LATENCY, &s->latency, sizeof(s->latency));
-        srt_setsockopt(fd, SOL_SOCKET, SRTO_PEERLATENCY, &s->latency, sizeof(s->latency));
-        // SRTO_LATENCY already seeds RCVLATENCY, but set it explicitly so
-        // the receive floor for publishers doesn't depend on the alias.
-        srt_setsockopt(fd, SOL_SOCKET, SRTO_RCVLATENCY, &s->latency, sizeof(s->latency));
+        //   max(player.RCVLATENCY, our.PEERLATENCY)).
+        // SRTO_LATENCY sets both at once, but set RCVLATENCY explicitly
+        // too — and check each return — because a publisher was observed
+        // negotiating 120ms with latency_min=500, i.e. the floor was not
+        // landing on the socket and the failure was being swallowed.
+        if (srt_setsockopt(fd, SOL_SOCKET, SRTO_LATENCY, &s->latency, sizeof(s->latency)) < 0)
+            spdlog::warn("[{}] CSLSSrt::libsrt_setup, SRTO_LATENCY={} failed: {}.",
+                         fmt::ptr(this), s->latency, srt_getlasterror_str());
+        if (srt_setsockopt(fd, SOL_SOCKET, SRTO_PEERLATENCY, &s->latency, sizeof(s->latency)) < 0)
+            spdlog::warn("[{}] CSLSSrt::libsrt_setup, SRTO_PEERLATENCY={} failed: {}.",
+                         fmt::ptr(this), s->latency, srt_getlasterror_str());
+        if (srt_setsockopt(fd, SOL_SOCKET, SRTO_RCVLATENCY, &s->latency, sizeof(s->latency)) < 0)
+            spdlog::warn("[{}] CSLSSrt::libsrt_setup, SRTO_RCVLATENCY={} failed: {}.",
+                         fmt::ptr(this), s->latency, srt_getlasterror_str());
     }
 
     // SRTO_PEERIDLETIMEO bounds how long a connected peer may go fully silent

--- a/src/core/SLSSrt.cpp
+++ b/src/core/SLSSrt.cpp
@@ -165,6 +165,11 @@ void CSLSSrt::libsrt_set_latency(int latency)
     m_sc.latency = latency;
 }
 
+void CSLSSrt::libsrt_set_peer_idle_timeout(int timeout_ms)
+{
+    m_sc.peer_idle_timeout = timeout_ms;
+}
+
 void CSLSSrt::libsrt_set_passphrase(const char *passphrase, int pbkeylen)
 {
     if (passphrase != NULL)
@@ -286,6 +291,30 @@ int CSLSSrt::libsrt_setup(int port, bool srtla_patches)
         // viewer-link jitter.
         srt_setsockopt(fd, SOL_SOCKET, SRTO_LATENCY, &s->latency, sizeof(s->latency));
         srt_setsockopt(fd, SOL_SOCKET, SRTO_PEERLATENCY, &s->latency, sizeof(s->latency));
+    }
+
+    // SRTO_PEERIDLETIMEO bounds how long a connected peer may go fully silent
+    // (no data, no keepalive) before libsrt declares the link broken. The
+    // belabox SRT fork raises the default so bonded-cellular gaps on the
+    // encoder<->server SRTLA leg don't kill a healthy publisher. The cost is
+    // that when an encoder abandons a connection (SRT session reset / link
+    // flap) its SHUTDOWN frequently never reaches us over that same flapping
+    // path, so the stale server-side socket squats the stream key until
+    // idle_streams_timeout. Set as a listener pre-option here, it is inherited
+    // by every accepted socket. Publisher takeover already handles the
+    // reconnect case; this is the backstop for an encoder that dies without
+    // reconnecting, and is most useful where publishers reach SLS over a
+    // stable hop (e.g. a local srtla_rec terminating the bond). 0 leaves the
+    // fork/libsrt default untouched so bonded direct-SRTLA deploys keep their
+    // tolerance.
+    if (s->peer_idle_timeout > 0)
+    {
+        int peer_idle = s->peer_idle_timeout;
+        if (srt_setsockopt(fd, SOL_SOCKET, SRTO_PEERIDLETIMEO, &peer_idle, sizeof(peer_idle)) < 0)
+            spdlog::warn("[{}] CSLSSrt::libsrt_setup, srt_setsockopt SRTO_PEERIDLETIMEO={} failed: {}.",
+                         fmt::ptr(this), peer_idle, srt_getlasterror_str());
+        else
+            spdlog::info("[{}] CSLSSrt::libsrt_setup, SRTO_PEERIDLETIMEO set to {}ms.", fmt::ptr(this), peer_idle);
     }
     // Kernel UDP socket buffers. Defaults on Linux are ~200KB-1MB which
     // is too tight for SRT live streaming under bursty traffic: when

--- a/src/core/SLSSrt.cpp
+++ b/src/core/SLSSrt.cpp
@@ -488,7 +488,7 @@ std::map<std::string, std::string> CSLSSrt::libsrt_parse_sid(char *sid)
             if (kv.size() == 2)
             {
 
-                ret[kv.at(0)] = kv.at(1);
+                ret[sls_trim(kv.at(0))] = sls_trim(kv.at(1));
             }
         }
     }
@@ -498,9 +498,9 @@ std::map<std::string, std::string> CSLSSrt::libsrt_parse_sid(char *sid)
         sls_split_string(sid, "/", items);
         if (items.size() >= 3)
         {
-            ret["h"] = items.at(0);
-            ret["sls_app"] = items.at(1);
-            ret["r"] = items.at(2);
+            ret["h"] = sls_trim(items.at(0));
+            ret["sls_app"] = sls_trim(items.at(1));
+            ret["r"] = sls_trim(items.at(2));
         }
     }
     return ret;

--- a/src/core/SLSSrt.hpp
+++ b/src/core/SLSSrt.hpp
@@ -118,6 +118,12 @@ public:
     std::map<std::string, std::string>  libsrt_parse_sid(char *sid);
 
     int libsrt_add_to_epoll(int eid, bool write);
+    // Arm/disarm SRT_EPOLL_OUT on an already-registered socket. Writable
+    // roles are registered ERR-only (see libsrt_add_to_epoll); OUT is
+    // armed dynamically only while a write is backpressured so the worker
+    // wakes when the send buffer drains, instead of busy-returning on a
+    // permanently-writable idle socket.
+    int libsrt_arm_epoll_out(bool enable);
     int libsrt_remove_from_epoll();
 
     int libsrt_getsockstate();

--- a/src/core/SLSSrt.hpp
+++ b/src/core/SLSSrt.hpp
@@ -59,6 +59,7 @@ typedef struct SRTContext
     int64_t inputbw;
     int oheadbw;
     int64_t latency;
+    int peer_idle_timeout; // SRTO_PEERIDLETIMEO (ms) for accepted sockets; 0 = leave libsrt/fork default
     int tlpktdrop;
     int nakreport;
     int64_t connect_timeout;
@@ -125,6 +126,7 @@ public:
     int libsrt_get_statistics(SRT_TRACEBSTATS *currentStats, int clear);
 
     void libsrt_set_latency(int latency);
+    void libsrt_set_peer_idle_timeout(int timeout_ms);
     void libsrt_set_passphrase(const char *passphrase, int pbkeylen);
 
     static int libsrt_neterrno();

--- a/src/core/SLSSrt.hpp
+++ b/src/core/SLSSrt.hpp
@@ -99,7 +99,7 @@ public:
     int libsrt_close();
 
     int libsrt_listen(int backlog);
-    int libsrt_set_listen_callback(srt_listen_callback_fn * listen_callback_fn);
+    int libsrt_set_listen_callback(srt_listen_callback_fn * listen_callback_fn, void *opaque = nullptr);
     int libsrt_accept();
 
     int libsrt_get_fd();

--- a/src/core/auth_reject_cache.cpp
+++ b/src/core/auth_reject_cache.cpp
@@ -1,0 +1,48 @@
+#include "auth_reject_cache.hpp"
+
+void AuthRejectCache::set_ttl(time_t ttl_seconds)
+{
+    if (ttl_seconds <= 0)
+        return;
+    std::lock_guard<std::mutex> lk(m_mtx);
+    m_ttl = ttl_seconds;
+}
+
+void AuthRejectCache::record_failure(const std::string &streamid)
+{
+    if (streamid.empty())
+        return;
+    time_t now = time(nullptr);
+    std::lock_guard<std::mutex> lk(m_mtx);
+    for (auto it = m_blocked.begin(); it != m_blocked.end();)
+    {
+        if (it->second <= now)
+            it = m_blocked.erase(it);
+        else
+            ++it;
+    }
+    m_blocked[streamid] = now + m_ttl;
+}
+
+bool AuthRejectCache::is_blocked(const std::string &streamid) const
+{
+    if (streamid.empty())
+        return false;
+    time_t now = time(nullptr);
+    std::lock_guard<std::mutex> lk(m_mtx);
+    auto it = m_blocked.find(streamid);
+    return it != m_blocked.end() && it->second > now;
+}
+
+void AuthRejectCache::cleanup()
+{
+    time_t now = time(nullptr);
+    std::lock_guard<std::mutex> lk(m_mtx);
+    for (auto it = m_blocked.begin(); it != m_blocked.end();)
+    {
+        if (it->second <= now)
+            it = m_blocked.erase(it);
+        else
+            ++it;
+    }
+}

--- a/src/core/auth_reject_cache.cpp
+++ b/src/core/auth_reject_cache.cpp
@@ -14,12 +14,18 @@ void AuthRejectCache::record_failure(const std::string &streamid)
         return;
     time_t now = time(nullptr);
     std::lock_guard<std::mutex> lk(m_mtx);
-    for (auto it = m_blocked.begin(); it != m_blocked.end();)
+    // Time-gate the sweep to at most once per second so a high-rate failure
+    // flood does not turn every insert into an O(n) scan of the map.
+    if (now != m_last_sweep)
     {
-        if (it->second <= now)
-            it = m_blocked.erase(it);
-        else
-            ++it;
+        for (auto it = m_blocked.begin(); it != m_blocked.end();)
+        {
+            if (it->second <= now)
+                it = m_blocked.erase(it);
+            else
+                ++it;
+        }
+        m_last_sweep = now;
     }
     m_blocked[streamid] = now + m_ttl;
 }

--- a/src/core/auth_reject_cache.hpp
+++ b/src/core/auth_reject_cache.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <ctime>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+// Process-wide negative cache of publisher streamids that recently failed
+// webhook authorization. The listener thread reads it inside the SRT
+// handshake callback (is_blocked), and worker threads write it on auth
+// failure (record_failure). This turns a streamid-rotating attacker's
+// repeat attempts on the same bad key into cheap handshake rejections
+// instead of a full accept plus on_event_url webhook lookup each time.
+//
+// One instance is owned by CSLSManager and injected into the publisher
+// listeners and the roles they create (dependency injection, no global
+// singleton). Stored as a shared_ptr by every holder so the cache outlives
+// any listener socket whose handshake callback still references it.
+class AuthRejectCache
+{
+public:
+    explicit AuthRejectCache(time_t ttl_seconds = 30) : m_ttl(ttl_seconds > 0 ? ttl_seconds : 30) {}
+
+    // TTL in seconds. Non-positive values are ignored so a missing config
+    // key (zeroed conf block) keeps the constructor default.
+    void set_ttl(time_t ttl_seconds);
+
+    // Block this streamid for the configured TTL. Sweeps expired entries on
+    // the way in, so the map stays bounded by the failure rate within one
+    // TTL window even under a rotating-key flood.
+    void record_failure(const std::string &streamid);
+
+    // True if the streamid is currently blocked. Read-only and const: an
+    // expired entry is treated as not blocked (lazy expiry) without
+    // mutating the map, so the latency-sensitive handshake path never has
+    // to sweep or take a write lock's worth of work.
+    bool is_blocked(const std::string &streamid) const;
+
+    // Drop expired entries. record_failure already sweeps on insert; this
+    // is exposed for an explicit periodic call if one is ever wired in.
+    void cleanup();
+
+private:
+    mutable std::mutex m_mtx;
+    std::unordered_map<std::string, time_t> m_blocked; // streamid -> expiry (epoch seconds)
+    time_t m_ttl;
+};

--- a/src/core/auth_reject_cache.hpp
+++ b/src/core/auth_reject_cache.hpp
@@ -44,4 +44,10 @@ private:
     mutable std::mutex m_mtx;
     std::unordered_map<std::string, time_t> m_blocked; // streamid -> expiry (epoch seconds)
     time_t m_ttl;
+    // Wall-clock second of the last full sweep. record_failure only sweeps
+    // once per second instead of on every insert, so a streamid-rotating
+    // flood that fails auth thousands of times a second pays an O(n) scan at
+    // most once per second rather than once per failure. Lazy expiry on read
+    // (is_blocked) keeps correctness independent of sweep cadence.
+    time_t m_last_sweep = 0;
 };

--- a/src/core/common.cpp
+++ b/src/core/common.cpp
@@ -654,6 +654,21 @@ int sls_drop_privileges(const char *user, const char *group)
 
 #define ADD_VECTOR_END(v, i) (v).push_back((i))
 
+// Clients occasionally paste a streamid with a stray newline or surrounding
+// whitespace (copy/paste from chat, config files with trailing \n). Those
+// bytes would otherwise fail sls_is_safe_name (control chars) or silently
+// produce a distinct map key / on_event_url, so trim once at the parse
+// boundary and everything downstream sees the clean value.
+std::string sls_trim(const std::string &str)
+{
+    const char *ws = " \t\r\n\f\v";
+    string::size_type first = str.find_first_not_of(ws);
+    if (first == string::npos)
+        return "";
+    string::size_type last = str.find_last_not_of(ws);
+    return str.substr(first, last - first + 1);
+}
+
 void sls_split_string(std::string str, std::string separator, std::vector<std::string> &result, int count)
 {
     result.clear();

--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -117,6 +117,7 @@ int sls_remove_pid();
 int sls_send_cmd(const char *cmd);
 int sls_drop_privileges(const char *user, const char *group);
 
+std::string sls_trim(const std::string &str);
 void sls_split_string(std::string str, std::string separator, std::vector<std::string> &result, int count = -1);
 std::string sls_find_string(std::vector<std::string> &src, std::string &dst, bool caseSensitive = true);
 

--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -56,6 +56,7 @@ using namespace std;
 
 #define SLS_OK SLSERRTAG(0x0, 0x0, 0x0, 0x0)                       ///< OK
 #define SLS_ERROR SLSERRTAG(0x0, 0x0, 0x0, 0x1)                    ///<
+#define SLS_PENDING SLSERRTAG(0x0, 0x0, 0x0, 0x2)                  ///< async result not ready yet (e.g. player-key webhook in flight)
 #define SLSERROR_BSF_NOT_FOUND SLSERRTAG(0xF8, 'B', 'S', 'F')      ///< Bitstream filter not found
 #define SLSERROR_BUG SLSERRTAG('B', 'U', 'G', '!')                 ///< Internal bug, also see SLSERROR_BUG2
 #define SLSERROR_BUFFER_TOO_SMALL SLSERRTAG('B', 'U', 'F', 'S')    ///< Buffer too small

--- a/src/core/sls_sid.cpp
+++ b/src/core/sls_sid.cpp
@@ -83,3 +83,20 @@ int sls_publisher_listen_callback(void *opaque, SRTSOCKET ns, int hsversion,
 
     return 0; // accept; the post-accept webhook still authorizes the key
 }
+
+int sls_player_listen_callback(void *opaque, SRTSOCKET ns, int hsversion,
+                               const struct sockaddr *peeraddr,
+                               const char *streamid)
+{
+    (void)opaque;
+    (void)hsversion;
+    (void)peeraddr;
+
+    if (!sls_validate_sid_format(streamid))
+    {
+        srt_setrejectreason(ns, SRT_REJ_ROGUE);
+        return -1;
+    }
+
+    return 0; // accept; the post-accept handler resolves and authorizes
+}

--- a/src/core/sls_sid.cpp
+++ b/src/core/sls_sid.cpp
@@ -1,0 +1,85 @@
+#include "sls_sid.hpp"
+
+#include <cstring>
+#include <vector>
+
+#include "auth_reject_cache.hpp"
+#include "common.hpp"
+
+using std::string;
+
+std::map<std::string, std::string> sls_parse_streamid(const char *sid)
+{
+    static const char stdhdr[] = "#!::";
+    std::map<std::string, std::string> ret;
+    if (!sid)
+        return ret;
+
+    if (strlen(sid) > 4 && memcmp(sid, stdhdr, 4) == 0)
+    {
+        std::vector<string> items;
+        sls_split_string(sid + 4, ",", items);
+        for (auto &i : items)
+        {
+            std::vector<string> kv;
+            sls_split_string(i, "=", kv);
+            if (kv.size() == 2)
+                ret[sls_trim(kv.at(0))] = sls_trim(kv.at(1));
+        }
+    }
+    else
+    {
+        std::vector<string> items;
+        sls_split_string(sid, "/", items);
+        if (items.size() >= 3)
+        {
+            ret["h"] = sls_trim(items.at(0));
+            ret["sls_app"] = sls_trim(items.at(1));
+            ret["r"] = sls_trim(items.at(2));
+        }
+    }
+    return ret;
+}
+
+bool sls_validate_sid_format(const char *sid)
+{
+    if (!sid || sid[0] == '\0')
+        return false;
+
+    std::map<std::string, std::string> kv = sls_parse_streamid(sid);
+    auto h = kv.find("h");
+    auto a = kv.find("sls_app");
+    auto r = kv.find("r");
+    if (h == kv.end() || a == kv.end() || r == kv.end())
+        return false;
+
+    return sls_is_safe_name(h->second.c_str()) &&
+           sls_is_safe_name(a->second.c_str()) &&
+           sls_is_safe_name(r->second.c_str());
+}
+
+int sls_publisher_listen_callback(void *opaque, SRTSOCKET ns, int hsversion,
+                                  const struct sockaddr *peeraddr,
+                                  const char *streamid)
+{
+    (void)hsversion;
+    (void)peeraddr;
+
+    if (!sls_validate_sid_format(streamid))
+    {
+        // Any reject reason serializes on the wire as 1000 + reason, which the
+        // upstream relay's is_srt_handshake_reject also counts as defense in
+        // depth. ROGUE ("incorrect data in handshake") fits a malformed sid.
+        srt_setrejectreason(ns, SRT_REJ_ROGUE);
+        return -1;
+    }
+
+    AuthRejectCache *cache = static_cast<AuthRejectCache *>(opaque);
+    if (cache != nullptr && cache->is_blocked(streamid))
+    {
+        srt_setrejectreason(ns, SRT_REJ_RESOURCE);
+        return -1;
+    }
+
+    return 0; // accept; the post-accept webhook still authorizes the key
+}

--- a/src/core/sls_sid.hpp
+++ b/src/core/sls_sid.hpp
@@ -31,3 +31,14 @@ bool sls_validate_sid_format(const char *sid);
 int sls_publisher_listen_callback(void *opaque, SRTSOCKET ns, int hsversion,
                                   const struct sockaddr *peeraddr,
                                   const char *streamid);
+
+// srt_listen_callback hook for the player listener. Rejects malformed
+// streamids at the handshake (SRT_REJ_ROGUE), before srt_accept and any
+// per-connection allocation, so a connect/RST flood of garbage streamids
+// is bounced cheaply instead of costing an accept + CSLSSrt + player object.
+// Format-only: the post-accept handler still resolves the publisher and (for
+// player-key apps) authorizes the key. The opaque pointer is unused. Returns
+// 0 to accept, -1 to reject. Must stay non-blocking.
+int sls_player_listen_callback(void *opaque, SRTSOCKET ns, int hsversion,
+                               const struct sockaddr *peeraddr,
+                               const char *streamid);

--- a/src/core/sls_sid.hpp
+++ b/src/core/sls_sid.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include <srt/srt.h>
+
+// Streamid parsing and handshake-time validation, factored out so the SRT
+// listen callback (which runs before srt_accept, with no CSLSSrt instance
+// yet) and the post-accept handler share one definition of a well-formed,
+// safe publisher streamid.
+
+// Parse an SRT publisher streamid into its key/value components. Handles
+// both the "#!::h=..,sls_app=..,r=.." form and the bare "host/app/stream"
+// form. Each value is trimmed of surrounding whitespace and newlines so a
+// stray paste artifact does not change the resulting map key.
+std::map<std::string, std::string> sls_parse_streamid(const char *sid);
+
+// True if the streamid is non-empty, parses, carries h / sls_app / r, and
+// all three pass sls_is_safe_name. Mirrors the post-accept checks in
+// SLSListenerHandler so the callback and the handler agree on "valid".
+bool sls_validate_sid_format(const char *sid);
+
+// srt_listen_callback hook for the publisher listener. Runs on the listener
+// thread during the handshake, before srt_accept and before any webhook
+// lookup. Rejects malformed streamids (SRT_REJ_ROGUE) and streamids in the
+// negative auth cache (SRT_REJ_RESOURCE). The opaque pointer is the
+// AuthRejectCache* injected at registration and may be null (format gate
+// still applies). Returns 0 to accept, -1 to reject. Must stay non-blocking:
+// a parse plus one short locked cache lookup, no HTTP or long-held locks.
+int sls_publisher_listen_callback(void *opaque, SRTSOCKET ns, int hsversion,
+                                  const struct sockaddr *peeraddr,
+                                  const char *streamid);

--- a/src/sls.conf
+++ b/src/sls.conf
@@ -130,6 +130,12 @@ srt {
         # Callback format:
         #   ?method=on_connect|on_close&role_name=&srt_url=<stream_url>
 
+        # Negative auth cache (optional). A publisher streamid whose on_event_url
+        # lookup returns non-200 is remembered for this many seconds; repeat
+        # attempts with the same key are rejected at the SRT handshake (no accept,
+        # no webhook), which blunts a streamid-rotating DoS. 0 uses the 30s default.
+        #auth_reject_cache_ttl 30;
+
         # Player key authentication (optional)
         # When enabled, player connections using the configured domain_player/app_player format
         # will have the stream name validated as a player key against the API endpoint

--- a/src/sls.conf
+++ b/src/sls.conf
@@ -104,6 +104,18 @@ srt {
         backlog 100;                    # Max simultaneous connection attempts
         idle_streams_timeout 30;        # Close idle streams after 30s (-1 = unlimited)
 
+        # SRTO_PEERIDLETIMEO (ms) applied to every accepted socket. Bounds how
+        # long a peer may go fully silent (no data, no keepalive) before the
+        # link is declared broken. 0 (default) leaves the SRT build's default,
+        # which the belabox fork raises so bonded-cellular gaps don't kill a
+        # healthy publisher. A reconnecting encoder is handled by publisher
+        # takeover regardless of this value. Set a tighter bound (e.g. 4000)
+        # only when publishers reach SLS over a stable hop (a local srtla_rec
+        # terminating the bond), so a publisher that dies without reconnecting
+        # is reaped before idle_streams_timeout. Avoid on direct bonded-SRTLA
+        # listeners, where it reduces tolerance for total-bond outages.
+        #peer_idle_timeout 4000;
+
         # Listener-wide SRT encryption. When set, libsrt enforces the passphrase
         # during the crypto handshake on every accepted connection (publishers
         # and players alike). This is orthogonal to player_key_auth_url, which

--- a/src/srt-live-server.cpp
+++ b/src/srt-live-server.cpp
@@ -264,6 +264,27 @@ int main(int argc, char *argv[])
         }
 
         int clear = req.has_param("reset") ? 1 : 0;
+        auto is_authorized = [&]() -> bool {
+            if (conf_srt->api_keys.empty() || !req.has_header("Authorization")) {
+                return false;
+            }
+            std::string auth_header = req.get_header_value("Authorization");
+            for (const auto& key : conf_srt->api_keys) {
+                if (key == auth_header) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if (clear && !is_authorized()) {
+            ret["status"] = "error";
+            ret["message"] = "Unauthorized: API key required or invalid for reset.";
+            res.status = 401;
+            res.set_header("Access-Control-Allow-Origin", cors_header);
+            res.set_content(ret.dump(), "application/json");
+            return;
+        }
 
         // If publisher param exists, use old logic
         if (req.has_param("publisher")) {
@@ -273,24 +294,7 @@ int main(int argc, char *argv[])
             }
         } else {
             // Publisher param missing: List all publishers if API key is configured
-            bool authorized = false;
-            if (conf_srt->api_keys.empty()) {
-                // No API keys configured, disallow access
-                authorized = false;
-            } else {
-                // API keys configured, check Authorization header
-                if (req.has_header("Authorization")) {
-                    std::string auth_header = req.get_header_value("Authorization");
-                    for (const auto& key : conf_srt->api_keys) {
-                        if (key == auth_header) {
-                            authorized = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (authorized) {
+            if (is_authorized()) {
                 ret = sls_manager->generate_json_for_all_publishers(clear);
                 // Status should already be 'ok' from generate_json_for_all_publishers
                 // No need to set 404 here, as we are listing all (even if empty)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added asynchronous webhook-based player authentication with result caching to reduce repeated validation calls
  * Implemented negative authentication cache to block failed stream IDs during handshakes
  * Added configurable peer idle timeout for socket connections
  * Enhanced viewer backpressure handling for more responsive egress draining

* **Improvements**
  * Enabled OpenSSL support for HTTP operations
  * Improved authorization logic for stats endpoint
  * Enhanced SRT listener callbacks with better handshake validation
  * Better role-aware latency negotiation for publishers and players

* **Documentation**
  * Added configuration examples for new auth and timeout settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->